### PR TITLE
chore: update versions on stable channel

### DIFF
--- a/manifest-stable.json
+++ b/manifest-stable.json
@@ -15,28 +15,28 @@
       "description": "The tx3 compiler",
       "repo_name": "tx3",
       "repo_owner": "tx3-lang",
-      "version": "^0.20.0"
+      "version": "^0.21.0"
     },
     {
       "name": "trix",
       "description": "The tx3 package manager",
       "repo_name": "trix",
       "repo_owner": "tx3-lang",
-      "version": "^0.25.0"
+      "version": "^0.25.1"
     },
     {
       "name": "tx3-lsp",
       "description": "A language server for tx3",
       "repo_name": "tx3-lsp",
       "repo_owner": "tx3-lang",
-      "version": "^0.8"
+      "version": "^0.9.0"
     },
     {
       "name": "dolos",
       "description": "A lightweight Cardano data node",
       "repo_name": "dolos",
       "repo_owner": "txpipe",
-      "version": "^1.1.1"
+      "version": "^1.2.0"
     },
     {
       "name": "cshell",


### PR DESCRIPTION
Update toolchain component versions on the **stable** channel to the latest GitHub releases.

| Component | Old | New |
|-----------|-----|-----|
| tx3c | `^0.20.0` | `^0.21.0` |
| trix | `^0.25.0` | `^0.25.1` |
| tx3-lsp | `^0.8` | `^0.9.0` |
| dolos | `^1.1.1` | `^1.2.0` |

`cshell` already at latest (`^0.14.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)