### PR TITLE
feat: add DX end-to-end test harness for the toolchain

### DIFF
--- a/.github/workflows/dx-e2e.yml
+++ b/.github/workflows/dx-e2e.yml
@@ -1,0 +1,70 @@
+name: DX E2E
+
+# Validates the developer experience of an assembled toolchain channel: install
+# via tx3up, then run the umbrella `e2e/` journeys (init → check → build → test,
+# a real local devnet round-trip) against the real trix/tx3c/dolos/cshell binaries.
+#
+# Native matrix only — a DX test must exercise the real per-platform install, so
+# no containers (a Linux container would drop macOS and misrepresent the install).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'manifest-*.json'        # gate the channel being shipped
+      - 'e2e/**'
+      - '.github/workflows/dx-e2e.yml'
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Toolchain channel to test'
+        required: false
+        default: 'stable'
+        type: choice
+        options: [stable, beta, nightly]
+  schedule:
+    - cron: '0 7 * * *'          # nightly drift check on the stable channel
+
+permissions:
+  contents: read
+
+jobs:
+  dx-e2e:
+    name: DX (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+    env:
+      CHANNEL: ${{ inputs.channel || 'stable' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # raises tx3up's GitHub rate limit
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install tx3up
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
+
+      - name: Put tx3up on PATH
+        run: |
+          # cargo-dist's shell installer drops the binary in one of these.
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run DX e2e (${{ env.CHANNEL }})
+        run: ./e2e/run.sh --channel "$CHANNEL" --no-isolate --artifacts-dir "$RUNNER_TEMP/dx-e2e-artifacts"
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dx-e2e-${{ matrix.runner }}
+          path: ${{ runner.temp }}/dx-e2e-artifacts
+          if-no-files-found: ignore
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ Umbrella-level skills (top-level `skills/`):
 - `skills/commit-umbrella/` — commit the umbrella repo after submodule pointers move, pre-checking that submodules are pushed, track latest `main`, and that grouping `AGENTS.md` routing is up to date.
 - `skills/channel-version-update/` — update toolchain component versions by checking GitHub releases and updating the manifest files.
 - `skills/add-language-feature/` — roll out a new Tx3 language feature (operator, expression form, builtin) across every toolchain layer: spec, grammar/AST, analysis/lowering, TIR/reduction, downstream consumers, docs, and agent skills.
+- `skills/add-e2e-journey/` — add a journey to the umbrella DX e2e harness (`e2e/`); the canonical guide for the journey contract and the `lib/common.sh` helper API.
 
 Per-grouping release skills (distributed under each grouping, like `sdks/skills/`):
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,153 @@
+# DX end-to-end tests
+
+These tests validate the **developer experience of the assembled toolchain**: that a
+developer who installs a channel and follows the normal journey
+(`init → check → build → test`, including a real local devnet round-trip) actually gets a
+working result. They exercise the real `trix`, `tx3c`, `dolos`, and `cshell` binaries
+together — interop that no single submodule's own tests cover. This is the umbrella's job,
+because only it knows the full channel composition (the `manifest-*.json` files) and is where
+releases are cut.
+
+This is deliberately *not* a duplicate of `tooling/trix/tests/e2e/`, which covers `trix init`
+structurally inside the trix crate. Here we cover the **runtime** journey against real
+helper binaries.
+
+## Layout
+
+```
+e2e/
+├── run.sh                          # entrypoint: resolve binaries, run journeys, summarize
+├── lib/common.sh                   # logging + fail-fast assertion helpers
+└── journeys/
+    ├── 01-basic-init/journey.sh    # init → check → build → test (offline devnet round-trip)
+    └── 02-lang-tour/
+        ├── journey.sh              # init → swap in feature-dense main.tx3 → check → build → inspect tir
+        └── main.tx3                # feature-dense fixture (a copy of the lang's lang_tour example)
+```
+
+A **journey** is a self-contained script that sources `lib/common.sh` and drives `trix`
+with the assertion helpers. `run.sh` discovers every `journeys/*/journey.sh`, runs each in
+an isolated temp working directory, and prints a markdown pass/fail summary, exiting
+non-zero if any journey fails.
+
+The two journeys cover complementary axes:
+
+| Journey | Covers | Scope |
+|---------|--------|-------|
+| **01-basic-init** | the default scaffold end to end, including a real devnet round-trip (trix + tx3c + dolos + cshell + resolver) | runtime |
+| **02-lang-tour** | the breadth of the language surface — env, records/variants, lists/maps/tuples, policies/assets, spread, locals, and the full Cardano construct set — pushed through `check → build → inspect tir` | compile/lower |
+
+`02-lang-tour` is compile/lower only: its feature-dense tx references hard-coded UTxOs, mints,
+and plutus scripts, so it can't resolve against a fresh devnet (the round-trip lives in 01). Its
+fixture tracks current language features, so it may outpace an older channel's `tx3c`.
+
+## Which binaries get tested
+
+`run.sh` picks the binary source — `trix` resolves its helper binaries (`tx3c`, `dolos`,
+`cshell`) from the tx3up install at `~/.tx3/default/bin`, or from per-tool `TX3_<TOOL>_PATH`
+overrides (see `tooling/trix/src/home.rs`). The runner uses that contract:
+
+| Mode | Command | What it validates |
+|------|---------|-------------------|
+| **channel** | `./e2e/run.sh --channel stable` | A released channel — black-box, exactly what ships. Installs via tx3up. |
+| **local** | `./e2e/run.sh --local` | Locally-built / unreleased binaries, via `TX3_TRIX_PATH` + `TX3_{TX3C,DOLOS,CSHELL}_PATH` (or PATH). Never touches `~/.tx3`. |
+| **default** | `./e2e/run.sh` | Whatever `trix` is already on your PATH. |
+
+In **channel** mode, local runs isolate the install under a throwaway `$HOME` so they never
+clobber your real `~/.tx3` (both tx3up and trix root at `~/.tx3`, and `dirs::home_dir()`
+respects `$HOME` on Unix). CI runners are already ephemeral, so they pass `--no-isolate`.
+
+## Running locally
+
+Prerequisites: `bash`, `git`, and the toolchain reachable in your chosen mode. The basic
+journey needs **no secrets and no network** beyond the one-time install — the devnet round-trip
+runs entirely on a local Dolos devnet with deterministic cshell wallets.
+
+```sh
+# Test the toolchain you already have installed:
+./e2e/run.sh
+
+# Install + test a specific channel (requires tx3up; isolates ~/.tx3 by default):
+./e2e/run.sh --channel beta
+
+# Test locally-built binaries (e.g. from cargo build in each submodule):
+TX3_TRIX_PATH=/path/to/trix \
+TX3_TX3C_PATH=/path/to/tx3c \
+TX3_DOLOS_PATH=/path/to/dolos \
+TX3_CSHELL_PATH=/path/to/cshell \
+  ./e2e/run.sh --local
+
+# Run one journey with live output:
+./e2e/run.sh --journey 01-basic-init --verbose
+```
+
+Install `tx3up` (only needed for `--channel`) with the bootstrap script:
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
+```
+
+On failure, `run.sh` preserves the per-journey working directory and a `<journey>.log` under
+its temp run-root (path printed at the end), and `--artifacts-dir <dir>` copies them somewhere
+stable for CI upload.
+
+## CI
+
+`.github/workflows/dx-e2e.yml` runs the harness in **channel** mode on the native matrix
+(`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`) — native because a DX test must validate
+the real per-platform install experience, which a Linux container would misrepresent (and drop
+macOS entirely). It triggers on:
+
+- pushes to `main` that touch `manifest-*.json` — gate that the channel being shipped works;
+- a nightly schedule — catch drift in already-released channels / upstream services;
+- manual dispatch with a `channel` input.
+
+The basic journey needs no secrets. Future live-network journeys would run in a separate,
+secrets-gated job.
+
+## Adding a journey
+
+See the **`add-e2e-journey` skill** (`skills/add-e2e-journey/SKILL.md`) — the canonical guide for
+the journey contract, the `lib/common.sh` helper API, fixtures, and `xfail`. In brief: add a
+`journeys/<NN>-<name>/journey.sh` that sources `${E2E_LIB}` and drives `"${TRIX}"` with the
+assertion helpers, and `run.sh` discovers it automatically.
+
+Planned journeys to grow coverage are tracked in
+[`plans/dx-e2e-journey-roadmap.md`](../plans/dx-e2e-journey-roadmap.md).
+
+## Findings (what this test has already surfaced)
+
+A DX test is also a friction detector. The first journey immediately found a real, reproducible
+toolchain bug:
+
+- **`trix test` balance assertions are broken (`xfail` in journey 01).** `trix test` resolves and
+  submits the scaffolded transfers fine, but its expect phase calls
+  `cshell wallet utxos "@bob"` — passing the literal `@`-prefixed placeholder instead of the
+  wallet name `bob`. The transaction path strips the `@` (`tooling/trix/src/commands/test.rs`,
+  `replace_placeholder_args`); the expect path does not
+  (`tooling/trix/src/commands/expect.rs:20`). cshell then errors with `CShell failed to get
+  wallet utxos`. Reproduces on both **stable** (trix 0.25.1) and **beta** (0.26.0). One-line fix
+  in trix: strip the leading `@` before the cshell call. The journey marks this step `xfail` with
+  that signature, so it auto-promotes to a hard failure the moment trix is fixed.
+
+- **Feature-dense compile/lower is slow.** On the `02-lang-tour` fixture, `trix build` and
+  `trix inspect tir` each take ~14s (vs. sub-second for the basic transfer). The TIR shows the
+  `source` input resolution re-embedded dozens of times — the record spread (`...source`) plus
+  repeated `source.fieldN` accesses look like they expand combinatorially in lowering. Worth a
+  profiler pass in `tx3c`/`tx3-cardano`. (The journey still passes; this is a latency observation.)
+
+Other things worth watching as journeys grow:
+
+- The `trix init` template (`tooling/trix/templates/tx3/test.toml.tpl`) is the source of truth for
+  the test shape — it matches the `Test` parser. The `tooling/trix/examples/test/` fixture uses a
+  different, non-parsing shape; don't copy from it.
+- **Time-to-first-green** — devnet startup + block intervals dominate the `trix test` step (~15s).
+- Command output strings the assertions match on (`"check passed"`, `"Dolos daemon started"`).
+
+## Hermeticity
+
+`trix test` leaks its Dolos devnet daemon when its expect phase errors (it returns before the
+`daemon.kill()`), so the runner reaps any dolos process it spawned (matched by the run's unique
+workdir) after each journey, and warns at startup if the devnet ports (8164/5164) are already in
+use. Channel mode never runs `tx3up use`, so it never repoints your active channel.

--- a/e2e/journeys/01-basic-init/journey.sh
+++ b/e2e/journeys/01-basic-init/journey.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Journey 01 — basic init.
+#
+# The canonical "zero to a working transaction" journey on the default scaffold,
+# fully offline (no secrets, no live network): scaffold a project, validate it,
+# build it, and run
+# a real devnet round-trip. The `trix test` step is the integration centerpiece
+# — it spins a local Dolos devnet, restores deterministic cshell wallets, submits
+# the scaffolded transfer transactions, and asserts the resulting balances —
+# exercising trix + tx3c + dolos + cshell + the resolver together.
+#
+# Run via e2e/run.sh, which provides $TRIX and an isolated working directory.
+
+source "${E2E_LIB:?E2E_LIB not set — run this journey via e2e/run.sh}"
+
+journey_begin "01-basic-init" "init → check → build → test (offline devnet round-trip)"
+
+# 1. Scaffold a fresh project and confirm the expected files land.
+run_cmd "trix init -y — scaffold a new project" "${TRIX}" init -y
+assert_exists "trix.toml"        "trix.toml created"
+assert_exists "main.tx3"         "main.tx3 created"
+assert_exists "tests/basic.toml" "tests/basic.toml created"
+assert_exists ".gitignore"       ".gitignore created"
+assert_exists "devnet.toml"      "devnet.toml created"
+
+# 2. Parse + analyze the protocol through the real tx3c binary.
+run_cmd "trix check — parse + analyze" "${TRIX}" check
+assert_output_contains "check passed"
+
+# 3. Compile to the Transaction Invocation Interface (TII).
+run_cmd "trix build — compile to TII" "${TRIX}" build
+assert_found "TII artifact produced under .tx3/tii" ".tx3/tii" "main.tii"
+
+# 4. Devnet round-trip. The scaffolded transfers must resolve and submit, and
+# the final balances must match. The submit half works; the balance-assertion
+# half is a *known, tracked toolchain bug*: `trix test`'s expect phase calls
+# `cshell wallet utxos "@bob"` with the literal placeholder instead of the
+# wallet name `bob` (the transaction path strips the `@`, the expect path in
+# trix's commands/expect.rs does not), so cshell errors with the signature
+# below. Reproduces on both stable (trix 0.25.1) and beta (0.26.0). Until trix
+# strips the `@`, this step is an xfail — it auto-promotes to a hard failure the
+# moment the bug is fixed (see xfail_cmd). The submit half is still asserted
+# strictly, so a regression there is caught regardless.
+xfail_cmd "trix test — devnet round-trip" "CShell failed to get wallet utxos" \
+  "${TRIX}" test tests/basic.toml
+assert_output_contains "Dolos daemon started" "devnet came up"
+assert_output_contains "bob sends 2 ada to alice" "transfer #1 was driven"
+assert_output_contains "alice sends 2 ada to bob" "transfer #2 was driven"
+
+journey_end

--- a/e2e/journeys/02-lang-tour/journey.sh
+++ b/e2e/journeys/02-lang-tour/journey.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Journey 02 — language tour.
+#
+# Coverage journey: swap the default scaffold's main.tx3 for a deliberately
+# feature-dense protocol (this directory's main.tx3, a copy of the lang's
+# lang_tour example) and push it through the full compile + lower pipeline. It
+# exercises the breadth of the language surface — env block, records, variants,
+# lists/maps/tuples, policies & assets, record spread, locals, and the whole
+# Cardano construct set (mint/burn, collateral, reference, withdrawal, the
+# certificate forms, plutus/native witnesses, treasury donation, metadata,
+# validity) — that the basic-init journey never touches.
+#
+# Scope is compile/lower only: the tx references hard-coded UTxOs, mints, and
+# plutus scripts, so it cannot resolve against a fresh devnet — that's why there
+# is no `trix test` step here (the round-trip lives in 01-basic-init).
+#
+# Run via e2e/run.sh, which provides $TRIX and an isolated working directory.
+
+source "${E2E_LIB:?E2E_LIB not set — run this journey via e2e/run.sh}"
+
+JOURNEY_HOME="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+journey_begin "02-lang-tour" "init → swap in feature-dense main.tx3 → check → build → inspect tir"
+
+# 1. Scaffold, then replace the trivial transfer with the feature-dense protocol.
+run_cmd "trix init -y — scaffold a new project" "${TRIX}" init -y
+cp "${JOURNEY_HOME}/main.tx3" main.tx3
+assert_exists "main.tx3" "feature-dense main.tx3 in place"
+
+# 2. Analyze the full language surface through tx3c.
+run_cmd "trix check — analyze the feature-dense protocol" "${TRIX}" check
+assert_output_contains "check passed"
+
+# 3. Compile to TII — proves every construct lowers to the interface.
+run_cmd "trix build — compile feature-dense protocol to TII" "${TRIX}" build
+assert_found "TII artifact produced under .tx3/tii" ".tx3/tii" "main.tii"
+
+# 4. Lower a single tx to TIR and confirm the Cardano + type-system constructs
+# actually made it through — not just that the build exited 0.
+run_cmd "trix inspect tir --tx my_tx — lower to TIR" "${TRIX}" inspect tir --tx my_tx
+assert_output_contains "treasury_donation"           "treasury donation lowered"
+assert_output_contains "plutus_witness"              "plutus witness lowered"
+assert_output_contains "native_witness"              "native witness lowered"
+assert_output_contains "vote_delegation_certificate" "certificate lowered"
+assert_output_contains "withdrawal"                  "withdrawal lowered"
+assert_output_contains "Map"                         "map type lowered"
+assert_output_contains "Tuple"                        "tuple type lowered"
+
+journey_end

--- a/e2e/journeys/02-lang-tour/main.tx3
+++ b/e2e/journeys/02-lang-tour/main.tx3
@@ -1,0 +1,133 @@
+env {
+    field_a: Int,
+    field_b: Bytes,
+    field_c: Bool,
+    field_d: List<Bytes>,
+}
+
+party MyParty;
+
+type MyRecord {
+    field1: Int,
+    field2: Bytes,
+    field3: Bytes,
+    field4: List<Int>,
+    field5: Map<Int, Bytes>,
+    field6: Tuple<Int, Bytes>,
+}
+
+type MyVariant {
+    Case1 {
+        field1: Int,
+        field2: Bytes,
+        field3: Int,
+    },
+    Case2,
+}
+
+policy OnlyHashPolicy = 0xABCDEF1234;
+
+asset StaticAsset = 0xABCDEF1234."MYTOKEN";
+
+policy FullyDefinedPolicy {
+    hash: 0xABCDEF1234,
+    script: 0xABCDEF1234,
+    ref: 0xABCDEF1234,
+}
+
+tx my_tx(
+    quantity: Int,
+    validUntil: Int,
+    metadata: Bytes,
+) {
+    input source {
+        from: MyParty,
+        datum_is: MyRecord,
+        min_amount: Ada(quantity) + min_utxo(named_output),
+        redeemer: MyVariant::Case1 {
+            field1: field_a,
+            field2: 0xAFAFAF,
+            field3: quantity,
+        },
+    }
+
+    mint {
+        amount: StaticAsset(100),
+        redeemer: (),
+    }
+
+    mint {
+        amount: AnyAsset(0xAB11223344, "OTHER_TOKEN", 10),
+        redeemer: (),
+    }
+
+    burn {
+        amount: StaticAsset(50),
+        redeemer: (),
+    }
+
+    collateral {
+        ref: 0xABCDEF#1,
+    }
+
+    reference ref_block {
+        ref: 0xABCDEF#2,
+    }
+
+    output named_output {
+        to: MyParty,
+        datum: MyRecord {
+            field1: quantity,
+            field2: (54 + 10) - (8 + 2),
+            field4: [1, 2, 3, source.field1],
+            field5: {1: "Value1", 2: "Value2",},
+            field6: (quantity, 0xAABB),
+            ...source
+        },
+        amount: AnyAsset(source.field3, source.field2, source.field1) + Ada(40) + min_utxo(named_output),
+    }
+
+    signers {
+        MyParty,
+        0x0F5B22E57FEEB5B4FD1D501B007A427C56A76884D4978FAFEF979D9C,
+    }
+
+    validity {
+        since_slot: tip_slot(),
+        until_slot: validUntil,
+    }
+
+    metadata {
+        1: metadata,
+        2: "Additional Metadata",
+    }
+
+    locals {
+        local_var: concat("Lang", "Tour"),
+        tuple_first: source.field6[0],
+    }
+
+    cardano::vote_delegation_certificate {
+        drep: 0x12345678,
+        stake: 0x87654321,
+    }
+
+    cardano::withdrawal {
+        from: MyParty,
+        amount: 100,
+        redeemer: (),
+    }
+
+    cardano::plutus_witness {
+        version: 2,
+        script: 0xABCDEF1234,
+    }
+
+    cardano::native_witness {
+        script: 0x12345678,
+    }
+
+    cardano::treasury_donation {
+        coin: 500,
+    }
+}

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Shared helpers for DX e2e journeys.
+#
+# A "journey" sources this file and then drives the `trix` CLI with the
+# assertion helpers below. Every helper is fail-fast: on a failed assertion it
+# prints a clear message and exits non-zero, which `e2e/run.sh` records as a
+# failed journey. Journeys therefore read as a linear script with no explicit
+# error handling.
+#
+# Contract from e2e/run.sh (exported into the journey's environment):
+#   TRIX         path/name of the trix binary to exercise
+#   E2E_VERBOSE  "1" to stream command output, "0" to capture it
+#   PWD          the journey's isolated working directory
+
+set -uo pipefail
+
+# --- presentation ----------------------------------------------------------
+
+if [[ -t 1 ]]; then
+  _C_RESET=$'\033[0m'; _C_DIM=$'\033[2m'; _C_RED=$'\033[31m'
+  _C_GREEN=$'\033[32m'; _C_YELLOW=$'\033[33m'; _C_BLUE=$'\033[34m'
+else
+  _C_RESET=""; _C_DIM=""; _C_RED=""; _C_GREEN=""; _C_YELLOW=""; _C_BLUE=""
+fi
+
+info() { printf '%s   %s%s\n' "${_C_BLUE}" "$*" "${_C_RESET}"; }
+ok()   { printf '%s ✔ %s%s\n' "${_C_GREEN}" "$*" "${_C_RESET}"; }
+warn() { printf '%s ! %s%s\n' "${_C_YELLOW}" "$*" "${_C_RESET}"; }
+err()  { printf '%s ✗ %s%s\n' "${_C_RED}" "$*" "${_C_RESET}" >&2; }
+
+die() { err "$*"; exit 1; }
+
+# Captured combined output of the most recent `run_cmd`, for assert_output_*.
+LAST_OUTPUT_FILE="${LAST_OUTPUT_FILE:-${PWD}/.last_cmd_output}"
+
+# --- journey scaffolding ---------------------------------------------------
+
+journey_begin() {
+  local title="$1" desc="${2:-}"
+  printf '\n%s== journey: %s ==%s\n' "${_C_DIM}" "${title}" "${_C_RESET}"
+  [[ -n "${desc}" ]] && printf '%s   %s%s\n' "${_C_DIM}" "${desc}" "${_C_RESET}"
+  return 0
+}
+
+journey_end() {
+  ok "journey passed"
+  return 0
+}
+
+# --- command runner --------------------------------------------------------
+
+# run_cmd "<human description>" <cmd> [args...]
+# Runs the command, capturing combined output to LAST_OUTPUT_FILE. Streams the
+# output live when E2E_VERBOSE=1. Aborts the journey if the command fails.
+run_cmd() {
+  local desc="$1"; shift
+  info "→ ${desc}"
+  : > "${LAST_OUTPUT_FILE}"
+
+  local rc
+  if [[ "${E2E_VERBOSE:-0}" == "1" ]]; then
+    "$@" 2>&1 | tee "${LAST_OUTPUT_FILE}"
+    rc=${PIPESTATUS[0]}
+  else
+    "$@" > "${LAST_OUTPUT_FILE}" 2>&1
+    rc=$?
+  fi
+
+  if [[ "${rc}" -ne 0 ]]; then
+    err "command failed (exit ${rc}): $*"
+    printf '%s---- captured output ----%s\n' "${_C_DIM}" "${_C_RESET}" >&2
+    cat "${LAST_OUTPUT_FILE}" >&2
+    printf '%s-------------------------%s\n' "${_C_DIM}" "${_C_RESET}" >&2
+    exit 1
+  fi
+  ok "${desc}"
+}
+
+# xfail_cmd "<label>" "<known-failure-signature>" <cmd> [args...]
+# For a step that is *expected to fail* because of a known, tracked upstream bug.
+# Captures output to LAST_OUTPUT_FILE, then:
+#   - fails the journey if the command FAILS with an *unexpected* signature
+#     (i.e. a new/different breakage we want to hear about);
+#   - tolerates (and loudly logs) the known failure when the signature matches;
+#   - if the command now SUCCEEDS, logs an "xpass" nudge to promote it to a
+#     strict assertion — so the xfail auto-surfaces once the bug is fixed.
+# Returns 0 in both the known-fail and xpass cases so the journey continues.
+xfail_cmd() {
+  local label="$1" signature="$2"; shift 2
+  info "→ ${label} ${_C_DIM}(xfail: ${signature})${_C_RESET}"
+  : > "${LAST_OUTPUT_FILE}"
+
+  local rc
+  if [[ "${E2E_VERBOSE:-0}" == "1" ]]; then
+    "$@" 2>&1 | tee "${LAST_OUTPUT_FILE}"; rc=${PIPESTATUS[0]}
+  else
+    "$@" > "${LAST_OUTPUT_FILE}" 2>&1; rc=$?
+  fi
+
+  if [[ "${rc}" -eq 0 ]]; then
+    warn "XPASS: '${label}' now succeeds — promote this to a strict assertion and drop the xfail"
+    return 0
+  fi
+  if grep -qiF -- "${signature}" "${LAST_OUTPUT_FILE}"; then
+    warn "XFAIL (known upstream bug): '${label}' failed with expected signature: ${signature}"
+    return 0
+  fi
+  err "'${label}' failed, but NOT with the known signature '${signature}' (exit ${rc})"
+  printf '%s---- captured output ----%s\n' "${_C_DIM}" "${_C_RESET}" >&2
+  cat "${LAST_OUTPUT_FILE}" >&2
+  printf '%s-------------------------%s\n' "${_C_DIM}" "${_C_RESET}" >&2
+  exit 1
+}
+
+# --- assertions ------------------------------------------------------------
+
+assert_exists() {
+  local path="$1" desc="${2:-file exists: $1}"
+  [[ -e "${path}" ]] || die "expected path is missing: ${path}"
+  ok "${desc}"
+}
+
+# assert_found "<desc>" <dir> <filename> — at least one matching file under dir.
+assert_found() {
+  local desc="$1" dir="$2" name="$3"
+  if [[ -d "${dir}" ]] && find "${dir}" -name "${name}" -type f | grep -q .; then
+    ok "${desc}"
+  else
+    die "expected to find a file named '${name}' under '${dir}'"
+  fi
+}
+
+# assert_output_contains "<needle>" ["<desc>"] — checks the last run_cmd output.
+assert_output_contains() {
+  local needle="$1" desc="${2:-output contains \"$1\"}"
+  if grep -qiF -- "${needle}" "${LAST_OUTPUT_FILE}"; then
+    ok "${desc}"
+  else
+    err "expected output to contain: ${needle}"
+    printf '%s---- captured output ----%s\n' "${_C_DIM}" "${_C_RESET}" >&2
+    cat "${LAST_OUTPUT_FILE}" >&2
+    printf '%s-------------------------%s\n' "${_C_DIM}" "${_C_RESET}" >&2
+    exit 1
+  fi
+}

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# DX end-to-end test runner for the Tx3 toolchain.
+#
+# Drives the real toolchain binaries through a developer's journey and reports
+# pass/fail per journey. It validates the *assembled* experience — that trix,
+# tx3c, dolos and cshell interoperate — which no single submodule's tests cover.
+#
+# Binary-source modes (which binaries the journeys exercise):
+#   --channel <stable|beta|nightly>   install that channel via tx3up, then test
+#                                      it (black-box test of what actually ships)
+#   --local                            use locally-built binaries: trix from PATH
+#                                      or $TX3_TRIX_PATH, and the helpers via
+#                                      $TX3_{TX3C,DOLOS,CSHELL}_PATH (or PATH).
+#                                      Validates unreleased changes; never touches
+#                                      ~/.tx3.
+#   (default)                          use whatever `trix` is already on PATH.
+#
+# See e2e/README.md for details.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/lib/common.sh"
+JOURNEY_DIR="${SCRIPT_DIR}/journeys"
+
+# --- defaults --------------------------------------------------------------
+
+MODE="path"            # path | channel | local
+CHANNEL=""
+ONLY_JOURNEY=""
+ISOLATE="auto"         # auto | yes | no (channel mode HOME isolation)
+VERBOSE="0"
+KEEP="0"
+ARTIFACTS_DIR=""
+
+usage() {
+  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  cat <<'EOF'
+
+Options:
+  --channel <ch>      Install + test a released channel via tx3up
+  --local             Test locally-built binaries (TX3_*_PATH / PATH)
+  --journey <name>    Run a single journey (directory name under journeys/)
+  --no-isolate        Channel mode: install into the ambient $HOME (CI default)
+  --isolate           Channel mode: install into a throwaway $HOME
+  --artifacts-dir D   On failure, copy preserved logs/workdirs into D
+  --keep              Keep journey workdirs even on success
+  --verbose           Stream child command output
+  -h, --help          Show this help
+EOF
+}
+
+# --- arg parsing -----------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel)      MODE="channel"; CHANNEL="${2:-}"; shift 2 ;;
+    --local)        MODE="local"; shift ;;
+    --journey)      ONLY_JOURNEY="${2:-}"; shift 2 ;;
+    --isolate)      ISOLATE="yes"; shift ;;
+    --no-isolate)   ISOLATE="no"; shift ;;
+    --artifacts-dir) ARTIFACTS_DIR="${2:-}"; shift 2 ;;
+    --keep)         KEEP="1"; shift ;;
+    --verbose|-v)   VERBOSE="1"; shift ;;
+    -h|--help)      usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+# shellcheck source=lib/common.sh
+source "${LIB}"
+
+[[ "${MODE}" == "channel" && -z "${CHANNEL}" ]] && die "--channel requires a value (stable|beta|nightly)"
+
+# --- run root + cleanup ----------------------------------------------------
+
+# Resolve to the real path (macOS symlinks /var -> /private/var); dolos logs the
+# real path, so this keeps the leaked-devnet reap below matching reliably.
+RUN_ROOT="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/dx-e2e.XXXXXX")" && pwd -P)"
+RUN_ID="$(basename "${RUN_ROOT}")"
+ISO_HOME=""            # throwaway HOME, when channel-mode isolation is active
+FAILED="0"
+
+cleanup() {
+  # The throwaway install is never useful for debugging — always reclaim it.
+  [[ -n "${ISO_HOME}" ]] && rm -rf "${ISO_HOME}"
+  # Keep the run logs/workdirs for inspection when something failed (or --keep).
+  if [[ "${FAILED}" == "1" ]]; then
+    warn "preserved run artifacts at: ${RUN_ROOT}"
+    if [[ -n "${ARTIFACTS_DIR}" ]]; then
+      mkdir -p "${ARTIFACTS_DIR}"
+      cp -R "${RUN_ROOT}/." "${ARTIFACTS_DIR}/" 2>/dev/null || true
+      warn "copied artifacts to: ${ARTIFACTS_DIR}"
+    fi
+    return
+  fi
+  [[ "${KEEP}" == "1" ]] || rm -rf "${RUN_ROOT}"
+}
+trap cleanup EXIT
+
+# --- binary resolution -----------------------------------------------------
+
+# Default: rely on PATH; modes below may override.
+TRIX="${TX3_TRIX_PATH:-trix}"
+
+resolve_helper() {
+  # resolve_helper <tool> — ensure trix can find a helper in --local mode by
+  # exporting TX3_<TOOL>_PATH. Honors a caller-provided override first.
+  local tool="$1"
+  local var="TX3_${tool^^}_PATH"
+  if [[ -n "${!var:-}" ]]; then
+    [[ -x "${!var}" ]] || die "${var}=${!var} is not an executable"
+    info "  ${tool}: ${!var} (from ${var})"
+    return
+  fi
+  local found; found="$(command -v "${tool}" 2>/dev/null || true)"
+  [[ -n "${found}" ]] || die "could not find '${tool}'; set ${var} or put it on PATH (--local)"
+  export "${var}=${found}"
+  info "  ${tool}: ${found} (from PATH)"
+}
+
+case "${MODE}" in
+  channel)
+    command -v tx3up >/dev/null 2>&1 || die \
+      "tx3up not found — install it first (see e2e/README.md), then re-run with --channel"
+
+    # Isolate by default for local invocations so we never clobber a developer's
+    # real ~/.tx3; CI runners are already ephemeral, so they pass --no-isolate.
+    if [[ "${ISOLATE}" == "yes" || ( "${ISOLATE}" == "auto" && -z "${CI:-}" ) ]]; then
+      ISO_HOME="$(mktemp -d "${TMPDIR:-/tmp}/dx-e2e-home.XXXXXX")"
+      export HOME="${ISO_HOME}"
+      info "isolating install under HOME=${HOME}"
+    fi
+
+    info "installing toolchain channel '${CHANNEL}' via tx3up"
+    # NOTE: deliberately NOT running `tx3up use` — that repoints ~/.tx3/default
+    # and would mutate the developer's active channel. We resolve the channel's
+    # own bin dir explicitly instead, so channel mode is non-destructive by
+    # construction (isolated or not). `install` only refreshes <channel>/bin.
+    tx3up --channel "${CHANNEL}" install || die "tx3up install failed for channel '${CHANNEL}'"
+
+    # Resolve against the channel's own bin dir, which tx3up definitively
+    # populates — robust against the ~/.tx3/default symlink not being set up.
+    chan_bin="${HOME}/.tx3/${CHANNEL}/bin"
+    [[ -d "${chan_bin}" ]] || die "channel bin dir not found after install: ${chan_bin}"
+    for tool in trix tx3c dolos cshell; do
+      [[ -x "${chan_bin}/${tool}" ]] || die \
+        "channel '${CHANNEL}' install is incomplete — missing '${tool}' at ${chan_bin}"
+    done
+    # Pin trix's helper resolution to the channel binaries and expose them on PATH.
+    export TX3_TX3C_PATH="${chan_bin}/tx3c"
+    export TX3_DOLOS_PATH="${chan_bin}/dolos"
+    export TX3_CSHELL_PATH="${chan_bin}/cshell"
+    export PATH="${chan_bin}:${PATH}"
+    TRIX="${chan_bin}/trix"
+    ;;
+
+  local)
+    TRIX="${TX3_TRIX_PATH:-$(command -v trix 2>/dev/null || true)}"
+    [[ -n "${TRIX}" ]] || die "trix not found — set TX3_TRIX_PATH or put trix on PATH (--local)"
+    info "trix: ${TRIX}"
+    # trix resolves these via TX3_<TOOL>_PATH (see trix home.rs); pin them so a
+    # local run never falls back to a ~/.tx3 install.
+    resolve_helper tx3c
+    resolve_helper dolos
+    resolve_helper cshell
+    ;;
+
+  path)
+    command -v "${TRIX}" >/dev/null 2>&1 || die \
+      "trix not found on PATH — install the toolchain, or use --channel / --local"
+    ;;
+esac
+
+export TRIX
+
+info "toolchain under test:"
+"${TRIX}" --version 2>&1 | sed 's/^/    /' || die "'${TRIX} --version' failed — toolchain not usable"
+
+# --- journey discovery -----------------------------------------------------
+
+journeys=()
+if [[ -n "${ONLY_JOURNEY}" ]]; then
+  [[ -f "${JOURNEY_DIR}/${ONLY_JOURNEY}/journey.sh" ]] \
+    || die "no such journey: ${ONLY_JOURNEY} (looked for journeys/${ONLY_JOURNEY}/journey.sh)"
+  journeys=("${JOURNEY_DIR}/${ONLY_JOURNEY}")
+else
+  for d in "${JOURNEY_DIR}"/*/; do
+    [[ -f "${d}journey.sh" ]] && journeys+=("${d%/}")
+  done
+fi
+[[ ${#journeys[@]} -gt 0 ]] || die "no journeys found under ${JOURNEY_DIR}"
+
+# --- devnet port preflight -------------------------------------------------
+
+# trix's devnet (Dolos) binds these fixed local ports. A pre-existing listener
+# (e.g. a leaked devnet from an earlier run, or `trix devnet` running elsewhere)
+# would poison the round-trip, so warn loudly. Best-effort via bash /dev/tcp.
+port_busy() { ( exec 3<>"/dev/tcp/127.0.0.1/$1" ) >/dev/null 2>&1; }
+for port in 8164 5164; do
+  if port_busy "${port}"; then
+    warn "port ${port} is already in use — a devnet may be running; the round-trip may be unreliable"
+  fi
+done
+
+# --- run journeys ----------------------------------------------------------
+
+names=(); results=(); durations=()
+
+for jdir in "${journeys[@]}"; do
+  name="$(basename "${jdir}")"
+  workdir="${RUN_ROOT}/${name}"
+  logfile="${RUN_ROOT}/${name}.log"
+  mkdir -p "${workdir}"
+
+  printf '\n%s──────── %s ────────%s\n' "${_C_DIM}" "${name}" "${_C_RESET}"
+  start="${SECONDS}"
+
+  if [[ "${VERBOSE}" == "1" ]]; then
+    ( cd "${workdir}" \
+        && E2E_LIB="${LIB}" TRIX="${TRIX}" E2E_VERBOSE=1 \
+           LAST_OUTPUT_FILE="${workdir}/.last_cmd_output" \
+           bash "${jdir}/journey.sh" ) 2>&1 | tee "${logfile}"
+    rc="${PIPESTATUS[0]}"
+  else
+    ( cd "${workdir}" \
+        && E2E_LIB="${LIB}" TRIX="${TRIX}" E2E_VERBOSE=0 \
+           LAST_OUTPUT_FILE="${workdir}/.last_cmd_output" \
+           bash "${jdir}/journey.sh" ) > "${logfile}" 2>&1
+    rc=$?
+  fi
+
+  dur=$(( SECONDS - start ))
+  names+=("${name}"); durations+=("${dur}s")
+
+  # Reap any devnet daemon trix spawned for this journey. trix kills its own
+  # dolos on the happy path, but leaks it when `trix test` errors in its expect
+  # phase — matching on this run's unique id + journey keeps reruns hermetic
+  # without touching a developer's own devnets.
+  pkill -f "dolos.*${RUN_ID}/${name}" >/dev/null 2>&1 || true
+
+  if [[ "${rc}" -eq 0 ]]; then
+    results+=("✅ pass")
+    [[ "${VERBOSE}" == "1" ]] || ok "${name} passed (${dur}s)"
+    [[ "${KEEP}" == "1" ]] || rm -rf "${workdir}"
+  else
+    results+=("❌ fail")
+    FAILED="1"
+    err "${name} failed (${dur}s) — log: ${logfile}"
+    if [[ "${VERBOSE}" != "1" ]]; then
+      printf '%s---- %s output ----%s\n' "${_C_DIM}" "${name}" "${_C_RESET}" >&2
+      cat "${logfile}" >&2
+      printf '%s--------------------%s\n' "${_C_DIM}" "${_C_RESET}" >&2
+    fi
+  fi
+done
+
+# --- summary ---------------------------------------------------------------
+
+echo
+echo "| Journey | Result | Duration |"
+echo "|---------|--------|----------|"
+for i in "${!names[@]}"; do
+  printf '| %s | %s | %s |\n' "${names[$i]}" "${results[$i]}" "${durations[$i]}"
+done
+echo
+
+if [[ "${FAILED}" == "1" ]]; then
+  err "DX e2e: one or more journeys failed."
+  exit 1
+fi
+ok "DX e2e: all journeys passed."

--- a/plans/dx-e2e-findings-followups.md
+++ b/plans/dx-e2e-findings-followups.md
@@ -1,0 +1,114 @@
+# Plan: DX e2e harness — findings follow-ups
+
+Status: **open / not started** — the harness is in place (`e2e/`); these are the
+fixes for what it surfaced on first run.
+Scope: `tooling/trix` (the `test` expect path), `lang/tx3` (TIR lowering perf),
+and the `e2e/` harness itself (xfail promotion + future journeys).
+Origin: the umbrella DX e2e harness landed 2026-06-16 (`e2e/run.sh`, journeys
+`01-basic-init` and `02-lang-tour`). Running it against the installed beta
+toolchain (trix 0.26.0 / tx3c 0.22.0 / dolos 1.2.0 / cshell 0.14.0) — and
+cross-checking stable (trix 0.25.1 / tx3c 0.21.0) — produced two findings,
+recorded in `e2e/README.md` (§ Findings) and worth fixing upstream.
+Related: [`e2e/README.md`](../e2e/README.md) and the memory note
+`trix-test-expect-at-prefix-bug`.
+
+## Context
+
+The harness drives the real `trix`/`tx3c`/`dolos`/`cshell` binaries through a
+developer's journey — interop no single submodule's tests cover. Two journeys
+exist today: `01-basic-init` (default scaffold → offline devnet round-trip) and
+`02-lang-tour` (a feature-dense `main.tx3` pushed through `check → build →
+inspect tir`). The first runs of both immediately exposed one correctness bug
+and one performance smell. Neither blocks the harness (journey 01 brackets the
+bug as an `xfail`; journey 02 still passes), but both are real and tracked here
+so they aren't lost.
+
+## Workstreams
+
+### 1. Fix `trix test` balance assertions (`@`-prefix not stripped)
+
+`trix test` resolves and submits the scaffolded transfers fine, but its
+expect/balance phase errors with `CShell failed to get wallet utxos`.
+**Root cause** (unambiguous in the code): `tooling/trix/src/commands/expect.rs`
+(~line 20) calls `cshell::wallet_utxos(test_home, &expect.from)` with the literal
+placeholder `"@bob"`, while cshell wallets are named `bob` (no `@`). The
+transaction path already strips the `@` (`tooling/trix/src/commands/test.rs`,
+`replace_placeholder_args`); the expect path does not.
+`tooling/trix/src/spawn/cshell.rs` `wallet_utxos` then shells out to
+`cshell wallet utxos "@bob" …`, which exits non-zero. Reproduces identically on
+**stable** (trix 0.25.1) and **beta** (0.26.0), so it is not a regression.
+
+Secondary bug in the same path: `trix test` **leaks its Dolos daemon** when the
+expect phase errors — `expect::expect_utxo(...)?` returns via `?` before
+`devnet.daemon.kill()` in `commands/test.rs`. (The e2e runner reaps it as a
+workaround; the leak should still be fixed.)
+
+The fix:
+- strip the leading `@` before the cshell call in `expect_utxo` (mirror
+  `replace_placeholder_args`), e.g. resolve `expect.from.trim_start_matches('@')`
+  — or better, resolve it to the wallet name the same way the tx path does;
+- run the devnet teardown unconditionally (move `daemon.kill()` past the expect
+  step, or wrap the body so the daemon is killed on the error path too);
+- add a trix unit/e2e test that asserts the expect path queries `bob`, not
+  `@bob`.
+
+Once shipped, the `01-basic-init` round-trip stops matching the xfail signature
+and `xfail_cmd` prints an **XPASS** nudge — at that point promote the step in
+`e2e/journeys/01-basic-init/journey.sh` back to a strict
+`run_cmd … trix test …` + `assert_output_contains "Test Passed"` and drop the
+xfail.
+
+### 2. Investigate feature-dense compile/lower latency
+
+On the `02-lang-tour` fixture (~70 lines), `trix build` and `trix inspect tir`
+each take **~14s**, versus sub-second for the basic transfer. The emitted TIR
+shows the `source` input-resolution expression
+(`EvalParam.ExpectInput["source", { … }]`) re-embedded **dozens of times** — once
+per `source.fieldN` access and per element of the `...source` record spread in
+`output named_output`. This looks like the lowering/reduction expands the input
+resolution combinatorially instead of resolving it once and referencing it.
+
+The goal: profile `tx3c` build + lower on the `02-lang-tour` fixture and remove
+the blow-up — likely common-subexpression / memoization of an input's resolved
+representation so property accesses and spreads reference a single resolved node
+rather than re-deriving the full `ExpectInput` each time. The work is in
+`lang/tx3` — the analyze→lower passes in `crates/tx3-lang` and the Cardano
+lowering in `crates/tx3-cardano` (confirm which pass duplicates the node before
+choosing where to fix). Validate the TIR is semantically unchanged (the resolver
+must still see the same effective values).
+
+### 3. Harden the harness around these findings
+
+Small, harness-local follow-ups that the findings motivate:
+- **CI cadence for slow journeys.** `02-lang-tour` is ~31s today (≈ workstream 2);
+  until that lands, consider running the slower coverage journeys on a separate
+  cadence/job from the fast `01` gate (the runner already supports `--journey`).
+- **Promotion checklist.** When workstream 1 ships, flip journey 01's xfail
+  (above) and update `e2e/README.md` § Findings + the memory note.
+- **Keep the lang-tour fixture current.** `02-lang-tour/main.tx3` tracks the
+  language surface; refresh it from `lang/tx3/examples/lang_tour.tx3` when new
+  constructs land so coverage doesn't rot (note: it may outpace older channels'
+  `tx3c`).
+
+## Sequencing
+
+1. Workstream 1 (trix expect fix + daemon teardown) — small, self-contained, and
+   unblocks the headline round-trip assertion. Ship in `tooling/trix`, bump the
+   pointer, then promote journey 01's xfail.
+2. Workstream 2 (lowering perf) — independent; needs a profiler pass in `lang/tx3`
+   before a fix shape is chosen. Larger and lower-urgency than 1.
+3. Workstream 3 — fold in alongside 1 and 2 as each lands.
+
+## Verification
+
+- §1: a fixed trix makes `trix test` on the default scaffold print `Test Passed`
+  and exit 0; the `01-basic-init` round-trip step, once promoted to strict, stays
+  green; no Dolos daemon survives a failed/early-exiting `trix test` (the runner's
+  post-journey reap finds nothing to kill). Add a trix test for the `@`-strip.
+- §2: re-run `./e2e/run.sh --journey 02-lang-tour --verbose`; `trix build` and
+  `trix inspect tir` drop from ~14s toward the basic-transfer baseline, with
+  byte-identical (or provably equivalent) TIR. Consider a soft time budget in the
+  journey once the target is known.
+- §3: the fast gate and the slower coverage journeys run on their intended
+  cadences; `e2e/README.md` § Findings and the memory note reflect the shipped
+  fixes.

--- a/plans/dx-e2e-journey-roadmap.md
+++ b/plans/dx-e2e-journey-roadmap.md
@@ -1,0 +1,107 @@
+# Plan: DX e2e harness — journey roadmap
+
+Status: **open / not started** — the harness ships with `01-basic-init` and
+`02-lang-tour`; these are the candidate journeys to grow coverage.
+Scope: the `e2e/` harness (new `journeys/<NN>-<name>/`), plus the surfaces each
+journey exercises — `trix codegen` + an SDK (`sdks/`), the registry
+(`services/registry`), live TRP endpoints, and the `protocols/` fixtures.
+Origin: extracted from `e2e/README.md` so the runnable harness stays a lean
+reference and the roadmap lives with the other plans.
+Related: [`dx-e2e-findings-followups.md`](./dx-e2e-findings-followups.md) (the
+fixes for what the first journeys surfaced), [`e2e/README.md`](../e2e/README.md),
+and the `add-e2e-journey` skill (`skills/add-e2e-journey/SKILL.md`) — the
+canonical guide for actually authoring a journey.
+
+## Context
+
+Each journey is a self-contained script that drives the real `trix` binary
+through one developer scenario and asserts the outcome; `e2e/run.sh` discovers
+`journeys/*/journey.sh` automatically. Today's two cover the *runtime* round-trip
+on the default scaffold (`01`) and the *compile/lower* breadth of the language
+surface (`02`). The journeys below extend coverage outward along the developer
+journey — codegen, registry, live networks, real protocols. They are ordered by
+how self-contained they are: `03` needs only a Node toolchain; `06` needs the
+`trix test` fix first; `04`/`05` need external infra or secrets and belong in a
+separate CI job from the fast, offline `01` gate.
+
+Author each one with the `add-e2e-journey` skill — it owns the journey contract,
+the `lib/common.sh` helper API, fixtures, and `xfail` conventions. This plan only
+defines *what* each journey should exercise.
+
+## Workstreams
+
+### 3. `03-codegen-consume` — generated client compiles (and invokes)
+
+Exercise the `trix codegen` → generated SDK path that nothing in the harness
+touches yet. Scaffold, `trix codegen --plugin ts-client`, then compile the
+generated TypeScript client to prove the codegen output is well-formed against the
+project's TII.
+
+- **Phase A (offline, no devnet):** generate + typecheck/compile the client. The
+  ts-client templates come from `tx3-lang/web-sdk` (`.trix/client-lib`); assert the
+  output dir is populated and `tsc`/build succeeds. This is the cheap, high-value core.
+- **Phase B (round-trip):** import the generated client in a tiny host script and
+  invoke a tx against the local devnet (or `--skip-submit` to validate unsigned-CBOR
+  build). Pairs with the `01` devnet machinery.
+- **Deps/CI:** adds a Node toolchain (`actions/setup-node`) — still no secrets, so it
+  can ride the default matrix once Node is provisioned. Consider a second job to keep
+  the no-Node `01`/`02` gate minimal.
+
+### 4. `04-registry` — publish → use → invoke an interface
+
+Exercise the protocol-reuse path: `trix publish` a protocol to a registry, then in a
+separate consumer project `trix use <scope>/<name>:<ver>` and invoke the interface tx.
+
+- **Needs infra:** an OCI registry (`oci.tx3.land`, or a throwaway local registry the
+  journey stands up) plus publish auth (OIDC / GitHub App attestation — see
+  `tooling/trix/src/commands/publish.rs` and `interfaces/`). The publish + trust-pin
+  flow is the hard part; a local registry fixture keeps it hermetic.
+- **Scope:** registry-dependent; gate it in a job with whatever registry/auth it needs.
+  A reduced first cut can publish to a local registry and `use` it without live OIDC.
+
+### 5. `05-live-network` — preview/preprod invoke (secrets-gated)
+
+Invoke a real transfer against a live Cardano testnet (preview/preprod) via a Demeter
+TRP endpoint — the only journey that leaves the local devnet.
+
+- **Reuse:** mirror the existing SDK e2e harness `sdks/scripts/run-e2e-tests.sh` and its
+  env contract (`TRP_ENDPOINT_PREPROD`, `TRP_API_KEY_PREPROD`, funded test wallets
+  `TEST_PARTY_A/B_*`). Use the same GitHub secrets.
+- **Scope:** **secrets-gated, separate CI job** — never on the fast offline gate. Likely
+  `--profile preview`/`preprod` with funded identities; assert on the submitted tx /
+  resolver response rather than balances (testnet timing).
+
+### 6. `06-protocol-fixture` — a real protocol through `trix test`
+
+Run a real protocol from `protocols/<name>/` (each ships `trix.toml` + `main.tx3` +
+`tests/basic.toml`) through the harness, validating actual third-party protocols against
+the channel — not just the scaffold and the lang-tour fixture.
+
+- **Blocked on** the `trix test` expect `@`-prefix fix (workstream 1 of
+  `dx-e2e-findings-followups.md`) for the round-trip half to pass; until then it can run
+  `check` + `build` on a protocol fixture (still useful coverage), or bracket the round-trip
+  as an `xfail` like `01` does.
+- **Scope:** offline (uses the local devnet); pick a representative protocol (or
+  parametrize over several) and copy it into the journey workdir so the run is hermetic.
+
+## Sequencing
+
+1. `03-codegen-consume` Phase A — most self-contained (Node only), highest coverage/effort
+   ratio; do first.
+2. `06-protocol-fixture` (check/build slice) — cheap once a fixture is chosen; promote its
+   round-trip when the `trix test` fix lands.
+3. `03` Phase B (round-trip) — after Phase A, reuses `01`'s devnet path.
+4. `05-live-network` — independent; needs the secrets job wired up (reuse the SDK e2e
+   secrets). Lower urgency, higher value for release confidence.
+5. `04-registry` — last; the heaviest infra/auth lift.
+
+## Verification
+
+- Each journey is green in isolation (`./e2e/run.sh --journey <name> --verbose`) and in the
+  full suite, and passes the `add-e2e-journey` skill's Safety Checks (syntax, hermeticity —
+  no stray `dolos`, no `~/.tx3/default` repoint).
+- `03`: generated client dir populated and compiles; (Phase B) tx invokes against devnet.
+- `04`: `trix use` resolves the published interface and the interface tx invokes.
+- `05`: a real testnet submission succeeds via the Demeter endpoint (secrets present).
+- `06`: a `protocols/<name>` fixture passes `check`/`build` (and the round-trip once unblocked).
+- `e2e/README.md`'s journey table is updated as each lands; this plan's workstream is checked off.

--- a/skills/add-e2e-journey/SKILL.md
+++ b/skills/add-e2e-journey/SKILL.md
@@ -1,0 +1,146 @@
+# Add E2E Journey Skill
+
+## Purpose
+Add a new **journey** to the umbrella DX end-to-end harness (`e2e/`). A journey is a
+self-contained script under `e2e/journeys/<NN>-<name>/journey.sh` that drives the real
+`trix` binary (and, through it, `tx3c`/`dolos`/`cshell`) through one developer scenario and
+asserts the outcome. `e2e/run.sh` discovers every `journeys/*/journey.sh` automatically, so
+adding a journey is: create the directory, write the script against the shared helper API,
+and verify it locally. This skill is the canonical reference for that API and procedure —
+`e2e/README.md` intentionally defers to it rather than duplicating it.
+
+## Prerequisites
+- Run from the umbrella repo root with the `e2e/` harness present.
+- `bash`, and the toolchain reachable in at least one mode (a `trix` on PATH for `./e2e/run.sh`,
+  or `--local` / `--channel`). See `e2e/README.md` § "Which binaries get tested".
+- The basic, offline journeys need no secrets and no network beyond a one-time install.
+
+## Context
+
+### How a journey is run
+`run.sh` runs each journey as `bash journeys/<name>/journey.sh` in its **own throwaway working
+directory** (CWD = a fresh temp dir, *not* the journey directory), captures pass/fail + duration,
+prints a markdown summary, and exits non-zero if any journey fails. A failed assertion ends the
+journey non-zero; the runner preserves that journey's workdir + log for inspection.
+
+### The journey contract (env the runner provides)
+- `TRIX` — path/name of the `trix` binary under test. **Always invoke `"${TRIX}"`**, never a bare `trix`.
+- `E2E_LIB` — absolute path to `lib/common.sh`; the journey must `source` it.
+- `E2E_VERBOSE` — `1` to stream command output, `0` to capture it (helpers honor this).
+- `LAST_OUTPUT_FILE` — where `run_cmd`/`xfail_cmd` write the most recent command's combined output
+  (what `assert_output_contains` greps). Set by the runner; don't override it.
+
+### Helper API (`lib/common.sh`) — the single source of truth
+All assertion helpers are **fail-fast**: on failure they print a clear message and `exit 1`,
+which the runner records as a failed journey. So a journey reads as a linear script.
+
+- `journey_begin "<title>" "<one-line desc>"` — banner; call once at the top after sourcing.
+- `journey_end` — success marker; call once at the end.
+- `run_cmd "<desc>" <cmd> [args…]` — run a command; abort the journey if it exits non-zero.
+  Captures output to `LAST_OUTPUT_FILE`.
+- `assert_exists <path> ["<desc>"]` — the path exists in the workdir.
+- `assert_found "<desc>" <dir> <filename>` — at least one file named `<filename>` exists under `<dir>`.
+- `assert_output_contains "<needle>" ["<desc>"]` — the last `run_cmd`/`xfail_cmd` output contains
+  `<needle>` (case-insensitive, fixed-string).
+- `xfail_cmd "<label>" "<known-failure-signature>" <cmd> [args…]` — for a step **expected to fail**
+  because of a known, tracked upstream bug. Tolerates failure *only* when the output matches the
+  signature (real fail on any other signature); if the command starts **succeeding**, it logs an
+  `XPASS` nudge so the xfail auto-surfaces for promotion. Always assert the still-working sub-behavior
+  with `assert_output_contains` afterward.
+- `info` / `ok` / `warn` / `err` / `die "<msg>"` — logging + hard stop.
+
+### Conventions
+- **Numbering**: `NN-name`, zero-padded, in run order — `01-basic-init`, `02-lang-tour`, …
+  Reserve `01-basic-init` as the fast, offline default gate.
+- **Fixtures**: embed per-journey files in the journey directory and resolve them from the script
+  via `"$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"` (CWD is the throwaway workdir, not the
+  journey dir). See `02-lang-tour/main.tx3`.
+- **Scope**: a journey is either *runtime* (needs a working devnet round-trip, like `01`) or
+  *compile/lower* (like `02`, which can't resolve against a fresh devnet). Pick one and say which
+  in the banner.
+
+## Procedure
+
+### 1. Decide scope, number, and mode needs
+Name it `<NN>-<short-kebab>`. Decide: offline (no secrets) or network/secrets-gated? Runtime
+round-trip or compile/lower only? This determines the steps and the CI placement (§7).
+
+### 2. Scaffold the journey
+```bash
+mkdir -p e2e/journeys/<NN>-<name>
+$EDITOR e2e/journeys/<NN>-<name>/journey.sh
+chmod +x e2e/journeys/<NN>-<name>/journey.sh
+```
+Skeleton (copy, then fill in):
+```bash
+#!/usr/bin/env bash
+#
+# Journey <NN> — <title>.
+# <1–3 lines: what it covers and its scope (runtime vs compile/lower).>
+#
+# Run via e2e/run.sh, which provides $TRIX and an isolated working directory.
+
+source "${E2E_LIB:?E2E_LIB not set — run this journey via e2e/run.sh}"
+
+# Only if the journey ships fixtures:
+JOURNEY_HOME="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+journey_begin "<NN>-<name>" "<one-line description of the flow>"
+
+run_cmd "trix init -y — scaffold a new project" "${TRIX}" init -y
+# … drive trix; assert after each step …
+
+journey_end
+```
+
+### 3. Drive `trix` and assert
+Use `run_cmd` for each step and an assertion after it. Match `assert_output_contains` on the
+**stable human-output strings** trix prints (e.g. `"check passed"`, `"Dolos daemon started"`,
+`"Test Passed"`), and `assert_found ".tx3/tii" "main.tii"` for build artifacts. Keep the script
+linear — no manual `if`/exit handling; the helpers abort on failure.
+
+### 4. Embed fixtures (if needed)
+Drop fixture files in the journey directory, then in step 3 copy them into the workdir, e.g.
+`cp "${JOURNEY_HOME}/main.tx3" main.tx3` after `trix init -y`. Keep fixtures self-contained so the
+journey runs in every mode; refresh language-feature fixtures from the upstream example when new
+constructs land.
+
+### 5. Bracket known-broken steps with `xfail_cmd`
+If a step fails because of a *tracked* upstream bug, use `xfail_cmd "<label>" "<signature>" …`
+instead of `run_cmd`, then `assert_output_contains` the part that still works. Document the bug
+inline (root cause + where it's tracked). The xfail auto-promotes to a hard failure once fixed.
+
+### 6. Verify locally
+```bash
+bash -n e2e/journeys/<NN>-<name>/journey.sh           # syntax
+./e2e/run.sh --journey <NN>-<name> --verbose          # this journey, streamed
+./e2e/run.sh                                          # full suite still green
+```
+
+### 7. Place it in CI
+Offline journeys ride the default `.github/workflows/dx-e2e.yml` matrix automatically (they run
+once `run.sh` discovers them). Journeys that need **secrets** (live network) or are **slow** belong
+in a separate job/cadence — gate them so the fast `01` gate stays quick and secret-free.
+
+## Decision Guidelines
+- **Strict vs xfail**: assert strictly by default. Reach for `xfail_cmd` *only* for a known,
+  signature-stable upstream bug you've tracked (e.g. in `plans/` and a memory note) — never to
+  paper over a flaky or unexplained failure.
+- **Offline-first**: prefer journeys that need no secrets/network so they run on every push. Put
+  anything needing Demeter keys / live endpoints in a separate secrets-gated CI job.
+- **Match on stable output**: assert on the human strings trix is unlikely to reword; avoid matching
+  on volatile detail (hashes, timings, file paths).
+- **One scope per journey**: don't bolt a devnet round-trip onto a compile/lower journey whose tx
+  can't resolve — split it.
+- **Don't duplicate** `tooling/trix/tests/e2e/` (that covers `trix init` structurally in-crate); the
+  umbrella journeys cover the *runtime* path against real helper binaries.
+
+## Safety Checks
+- `bash -n` passes and the script is `chmod +x`.
+- The new journey is green **in isolation** (`--journey`) and in the **full suite**.
+- **Hermetic**: after the run, no stray `dolos` daemon survives (`pgrep -fl 'dolos.*daemon'`) and,
+  for channel mode, `~/.tx3/default` is unchanged (channel mode must never run `tx3up use`).
+- Update `e2e/README.md`'s journey table/layout to list the new journey (the table is reference;
+  the how-to stays here).
+- If the journey brackets a new xfail, record the bug in `plans/` and a memory note so its
+  promotion is tracked.


### PR DESCRIPTION
## What

Adds `e2e/` — a DX end-to-end test harness that drives the **real** `trix`/`tx3c`/`dolos`/`cshell`
binaries through a developer's journey and validates the *assembled* toolchain experience, which no
single submodule's tests cover. This is the umbrella's job: only it knows the full channel
composition (the `manifest-*.json` files) and is where releases are cut.

## Why

Existing tests are per-submodule (trix's in-crate `init` tests, the SDK e2e, tx3up install checks).
Nothing validated that an installed channel actually works end to end — so a manifest bump of
`dolos`/`cshell` could break interop silently.

## What's in it

- **`e2e/run.sh`** — orchestrator with a binary-source contract:
  - `--channel <stable|beta|nightly>` — install + black-box a released channel via tx3up
  - `--local` — locally-built / unreleased binaries via `TX3_{TRIX,TX3C,DOLOS,CSHELL}_PATH`
  - default — whatever `trix` is on PATH
- **Two journeys**:
  - `01-basic-init` — default scaffold → offline devnet round-trip (trix + tx3c + dolos + cshell + resolver)
  - `02-lang-tour` — a feature-dense `main.tx3` through `check → build → inspect tir` (language-surface coverage)
- **Hermetic** — reaps the dolos daemon `trix test` leaks on its error path, warns on busy devnet
  ports, and never repoints `~/.tx3/default`.
- **CI** (`.github/workflows/dx-e2e.yml`) — channel mode on a native `ubuntu-latest` /
  `ubuntu-24.04-arm` / `macos-latest` matrix; triggers on `manifest-*.json` changes, nightly, and
  dispatch. Native (not Docker) because a DX test must validate the real per-platform install, which
  a Linux container would misrepresent (and drop macOS).
- **`skills/add-e2e-journey/`** — canonical guide for authoring journeys (the README defers to it to
  avoid duplication).
- **`plans/`** — `dx-e2e-findings-followups.md` (fix what the harness found) and
  `dx-e2e-journey-roadmap.md` (candidate journeys: codegen-consume, registry, live-network, protocol
  fixtures).

## Finding (on the very first run)

The harness immediately surfaced a real, reproducible trix bug: `trix test`'s expect phase calls
`cshell wallet utxos "@bob"` with the literal placeholder instead of the wallet name `bob` — the
transaction path strips the `@` (`commands/test.rs`), the expect path does not
(`commands/expect.rs`). Balance assertions therefore fail on **stable (0.25.1)** and **beta
(0.26.0)**; one-line fix. The journey brackets it as an `xfail` keyed on the failure signature, which
**auto-promotes** to a hard failure the moment trix is fixed. Tracked in
`plans/dx-e2e-findings-followups.md`.

## Test plan

Validated locally on macOS against the installed beta toolchain:

- `./e2e/run.sh` (default) — both journeys green
- `./e2e/run.sh --channel beta --no-isolate` — green; confirmed `~/.tx3/default` unchanged (non-destructive)
- `--local` pinned at the stable binaries — green through `build`; confirmed the `trix test` bug reproduces on stable too
- Confirmed no leaked `dolos` daemons survive a run, and `bash -n` + ruby YAML lint pass

Scope: umbrella top-level only — no submodule pointers move.

Note: the workflow gates pushes to `main` (manifest/e2e changes), not `pull_request`, so it won't run
on this PR itself; happy to add a `pull_request` trigger if you'd like the harness to self-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
