### PR TITLE
feat: per-channel e2e CI jobs + composite action + 03-lang-edge journey

### DIFF
--- a/.github/actions/dx-e2e-run/action.yml
+++ b/.github/actions/dx-e2e-run/action.yml
@@ -1,0 +1,52 @@
+name: 'Run DX e2e'
+description: 'Install a toolchain channel via tx3up and run one DX e2e journey.'
+
+inputs:
+  channel:
+    description: 'Toolchain channel to install and test (stable, beta, …).'
+    required: true
+  journey:
+    description: 'Journey directory name under e2e/journeys/.'
+    required: true
+  github-token:
+    description: "Token for tx3up's GitHub downloads (raises the rate limit)."
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install tx3up
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        curl --proto '=https' --tlsv1.2 -LsSf \
+          https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
+
+    - name: Put tx3up on PATH
+      shell: bash
+      run: |
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Cache channel toolchain
+      uses: actions/cache@v4
+      with:
+        path: ~/.tx3/${{ inputs.channel }}
+        key: tx3-${{ runner.os }}-${{ runner.arch }}-${{ inputs.channel }}-${{ hashFiles(format('manifest-{0}.json', inputs.channel)) }}
+
+    - name: Run DX e2e
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: ./e2e/run.sh --channel "${{ inputs.channel }}" --journey "${{ inputs.journey }}" --no-isolate --artifacts-dir "$RUNNER_TEMP/dx-e2e-artifacts"
+
+    - name: Upload artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: dx-e2e-${{ inputs.channel }}-${{ inputs.journey }}-${{ runner.os }}-${{ runner.arch }}
+        path: ${{ runner.temp }}/dx-e2e-artifacts
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.github/workflows/dx-e2e.yml
+++ b/.github/workflows/dx-e2e.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        journey: [01-basic-init, 02-lang-tour]   # comprehensive: every journey
+        journey: [01-basic-init, 02-lang-tour, 03-lang-edge]   # comprehensive: every journey
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dx-e2e-run
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        journey: [02-lang-tour]   # cherry-pick: edge-feature journeys only
+        journey: [02-lang-tour, 03-lang-edge]   # cherry-pick: edge-feature journeys only
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dx-e2e-run

--- a/.github/workflows/dx-e2e.yml
+++ b/.github/workflows/dx-e2e.yml
@@ -1,21 +1,21 @@
 name: DX E2E
 
-# One job per channel, each an {os × journey} matrix:
+# One job per channel, each an {os × journey} matrix. The shared per-cell steps
+# (install the channel via tx3up, cache it, run one journey) live in the local
+# composite action .github/actions/dx-e2e-run.
+#
 #   - stable: a comprehensive pass over *every* journey. Edge journeys whose
-#     `#@ min-tx3c` exceeds stable's tx3c just install + skip (green), and start
-#     running automatically once the feature graduates to stable.
-#   - beta: cherry-picked *edge-feature* journeys — the ones exercising language
-#     features that only exist on beta (so stable doesn't yet run them for real).
+#     `#@ min-tx3c` exceeds stable's tx3c install + skip (green), and auto-run
+#     once the feature graduates to stable.
+#   - beta: cherry-picked *edge-feature* journeys only (e.g. 02-lang-tour's
+#     tuples) — stable already covers everything broadly.
 #
 # Compat lives in one place: the journey's `#@ min-tx3c` header, enforced by the
 # runner's skip gate. Native runners only — a DX test must exercise the real
 # per-platform install, which a Linux container can't.
 #
-# Adding a journey: add it to `stable`'s journey list (always). If it exercises a
+# Adding a journey: add it to `stable`'s journey list (always); if it exercises a
 # beta-only feature, also add it to `beta`'s list.
-#
-# The two jobs are intentionally parallel copies; if a third channel is added,
-# factor the shared steps into a composite action.
 
 on:
   push:
@@ -24,6 +24,7 @@ on:
       - 'manifest-*.json'
       - 'e2e/**'
       - '.github/workflows/dx-e2e.yml'
+      - '.github/actions/dx-e2e-run/**'
   workflow_dispatch:
   schedule:
     - cron: '0 7 * * *'          # nightly drift check
@@ -40,34 +41,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         journey: [01-basic-init, 02-lang-tour]   # comprehensive: every journey
-    env:
-      CHANNEL: stable
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # raises tx3up's GitHub rate limit
     steps:
       - uses: actions/checkout@v4
-      - name: Install tx3up
-        run: |
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
-      - name: Put tx3up on PATH
-        run: |
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - name: Cache channel toolchain
-        uses: actions/cache@v4
+      - uses: ./.github/actions/dx-e2e-run
         with:
-          path: ~/.tx3/${{ env.CHANNEL }}
-          key: tx3-${{ runner.os }}-${{ runner.arch }}-${{ env.CHANNEL }}-${{ hashFiles(format('manifest-{0}.json', env.CHANNEL)) }}
-      - name: Run DX e2e
-        run: ./e2e/run.sh --channel "$CHANNEL" --journey "${{ matrix.journey }}" --no-isolate --artifacts-dir "$RUNNER_TEMP/dx-e2e-artifacts"
-      - name: Upload artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: dx-e2e-${{ env.CHANNEL }}-${{ matrix.os }}-${{ matrix.journey }}
-          path: ${{ runner.temp }}/dx-e2e-artifacts
-          if-no-files-found: ignore
-          retention-days: 7
+          channel: stable
+          journey: ${{ matrix.journey }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   beta:
     name: beta (${{ matrix.os }} · ${{ matrix.journey }})
@@ -77,31 +57,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         journey: [02-lang-tour]   # cherry-pick: edge-feature journeys only
-    env:
-      CHANNEL: beta
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # raises tx3up's GitHub rate limit
     steps:
       - uses: actions/checkout@v4
-      - name: Install tx3up
-        run: |
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
-      - name: Put tx3up on PATH
-        run: |
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - name: Cache channel toolchain
-        uses: actions/cache@v4
+      - uses: ./.github/actions/dx-e2e-run
         with:
-          path: ~/.tx3/${{ env.CHANNEL }}
-          key: tx3-${{ runner.os }}-${{ runner.arch }}-${{ env.CHANNEL }}-${{ hashFiles(format('manifest-{0}.json', env.CHANNEL)) }}
-      - name: Run DX e2e
-        run: ./e2e/run.sh --channel "$CHANNEL" --journey "${{ matrix.journey }}" --no-isolate --artifacts-dir "$RUNNER_TEMP/dx-e2e-artifacts"
-      - name: Upload artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: dx-e2e-${{ env.CHANNEL }}-${{ matrix.os }}-${{ matrix.journey }}
-          path: ${{ runner.temp }}/dx-e2e-artifacts
-          if-no-files-found: ignore
-          retention-days: 7
+          channel: beta
+          journey: ${{ matrix.journey }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dx-e2e.yml
+++ b/.github/workflows/dx-e2e.yml
@@ -1,14 +1,21 @@
 name: DX E2E
 
-# Validates the DX of assembled toolchain channels on a static {os × channel ×
-# journey} matrix. Each cell installs that channel via tx3up and runs the one
-# journey; the runner skips (does not fail) journeys whose `#@ min-tx3c` floor the
-# channel can't meet — so e.g. the tuple-using lang-tour journey installs+skips on
-# stable (tx3c 0.21) and runs on beta (0.22). Compat lives in exactly one place:
-# the journey's min-tx3c header. Native matrix only — a DX test must exercise the
-# real per-platform install, which a Linux container can't.
+# One job per channel, each an {os × journey} matrix:
+#   - stable: a comprehensive pass over *every* journey. Edge journeys whose
+#     `#@ min-tx3c` exceeds stable's tx3c just install + skip (green), and start
+#     running automatically once the feature graduates to stable.
+#   - beta: cherry-picked *edge-feature* journeys — the ones exercising language
+#     features that only exist on beta (so stable doesn't yet run them for real).
 #
-# Adding a journey: add it to the matrix `journey` list below.
+# Compat lives in one place: the journey's `#@ min-tx3c` header, enforced by the
+# runner's skip gate. Native runners only — a DX test must exercise the real
+# per-platform install, which a Linux container can't.
+#
+# Adding a journey: add it to `stable`'s journey list (always). If it exercises a
+# beta-only feature, also add it to `beta`'s list.
+#
+# The two jobs are intentionally parallel copies; if a third channel is added,
+# factor the shared steps into a composite action.
 
 on:
   push:
@@ -25,44 +32,76 @@ permissions:
   contents: read
 
 jobs:
-  dx-e2e:
-    name: DX (${{ matrix.os }} · ${{ matrix.channel }} · ${{ matrix.journey }})
+  stable:
+    name: stable (${{ matrix.os }} · ${{ matrix.journey }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        channel: [stable, beta]
-        journey: [01-basic-init, 02-lang-tour]
+        journey: [01-basic-init, 02-lang-tour]   # comprehensive: every journey
     env:
+      CHANNEL: stable
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # raises tx3up's GitHub rate limit
     steps:
       - uses: actions/checkout@v4
-
       - name: Install tx3up
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
-
       - name: Put tx3up on PATH
         run: |
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
       - name: Cache channel toolchain
         uses: actions/cache@v4
         with:
-          path: ~/.tx3/${{ matrix.channel }}
-          key: tx3-${{ runner.os }}-${{ runner.arch }}-${{ matrix.channel }}-${{ hashFiles(format('manifest-{0}.json', matrix.channel)) }}
-
+          path: ~/.tx3/${{ env.CHANNEL }}
+          key: tx3-${{ runner.os }}-${{ runner.arch }}-${{ env.CHANNEL }}-${{ hashFiles(format('manifest-{0}.json', env.CHANNEL)) }}
       - name: Run DX e2e
-        run: ./e2e/run.sh --channel "${{ matrix.channel }}" --journey "${{ matrix.journey }}" --no-isolate --artifacts-dir "$RUNNER_TEMP/dx-e2e-artifacts"
-
+        run: ./e2e/run.sh --channel "$CHANNEL" --journey "${{ matrix.journey }}" --no-isolate --artifacts-dir "$RUNNER_TEMP/dx-e2e-artifacts"
       - name: Upload artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: dx-e2e-${{ matrix.os }}-${{ matrix.channel }}-${{ matrix.journey }}
+          name: dx-e2e-${{ env.CHANNEL }}-${{ matrix.os }}-${{ matrix.journey }}
+          path: ${{ runner.temp }}/dx-e2e-artifacts
+          if-no-files-found: ignore
+          retention-days: 7
+
+  beta:
+    name: beta (${{ matrix.os }} · ${{ matrix.journey }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        journey: [02-lang-tour]   # cherry-pick: edge-feature journeys only
+    env:
+      CHANNEL: beta
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # raises tx3up's GitHub rate limit
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install tx3up
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
+      - name: Put tx3up on PATH
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Cache channel toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.tx3/${{ env.CHANNEL }}
+          key: tx3-${{ runner.os }}-${{ runner.arch }}-${{ env.CHANNEL }}-${{ hashFiles(format('manifest-{0}.json', env.CHANNEL)) }}
+      - name: Run DX e2e
+        run: ./e2e/run.sh --channel "$CHANNEL" --journey "${{ matrix.journey }}" --no-isolate --artifacts-dir "$RUNNER_TEMP/dx-e2e-artifacts"
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dx-e2e-${{ env.CHANNEL }}-${{ matrix.os }}-${{ matrix.journey }}
           path: ${{ runner.temp }}/dx-e2e-artifacts
           if-no-files-found: ignore
           retention-days: 7

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -108,17 +108,20 @@ stable for CI upload.
 
 ## CI
 
-`.github/workflows/dx-e2e.yml` runs a static **`{os × channel × journey}` cross-product** matrix
-(`os` = `ubuntu-latest` / `ubuntu-24.04-arm` / `macos-latest`; `channel` = `stable` + `beta`;
-`journey` = the journey list). Each cell installs that channel via tx3up and runs the single
-journey. Incompatible cells aren't special-cased — the runner's `#@ min-tx3c` gate just **skips**
-them (e.g. `stable × 02-lang-tour` installs stable and skips, green), so compat lives in one place.
-Each cell caches `~/.tx3/<channel>` (keyed on the channel manifest) to amortize installs.
+`.github/workflows/dx-e2e.yml` runs **one job per channel**, each an `{os × journey}` matrix over
+the native runners (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`):
 
-Native matrix only — a DX test must validate the real per-platform install, which a Linux container
-would misrepresent (and drop macOS). Triggers: pushes to `main` touching `manifest-*.json` /
-`e2e/**` / the workflow; a nightly schedule; manual dispatch. **Adding a journey** means adding it
-to the matrix `journey` list (and a channel to the `channel` list to test more channels).
+- **`stable`** — a comprehensive pass over *every* journey. Edge journeys whose `#@ min-tx3c`
+  exceeds stable's `tx3c` install and **skip** (green), and start running automatically once the
+  feature graduates to stable (auto-heal).
+- **`beta`** — cherry-picked *edge-feature* journeys (the ones exercising features only on beta, like
+  `02-lang-tour`'s tuples). Stable already covers everything broadly, so beta stays focused.
+
+Compat lives in one place — the journey's `#@ min-tx3c` header, enforced by the runner's skip gate —
+so the workflow needs no per-cell compat config. Each cell caches `~/.tx3/<channel>` (keyed on the
+channel manifest) to amortize installs. Native runners only: a DX test must validate the real
+per-platform install, which a Linux container would misrepresent (and drop macOS). Triggers: pushes
+to `main` touching `manifest-*.json` / `e2e/**` / the workflow; a nightly schedule; manual dispatch.
 
 No journey here needs secrets. Future live-network journeys would run in a separate, secrets-gated
 job.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -30,12 +30,13 @@ with the assertion helpers. `run.sh` discovers every `journeys/*/journey.sh`, ru
 an isolated temp working directory, and prints a markdown pass/fail summary, exiting
 non-zero if any journey fails.
 
-The two journeys cover complementary axes:
+The journeys cover complementary axes:
 
 | Journey | Covers | Scope |
 |---------|--------|-------|
 | **01-basic-init** | the default scaffold end to end, including a real devnet round-trip (trix + tx3c + dolos + cshell + resolver) | runtime |
 | **02-lang-tour** | the breadth of the language surface — env, records/variants, lists/maps/tuples, policies/assets, spread, locals, and the full Cardano construct set — pushed through `check → build → inspect tir` | compile/lower |
+| **03-lang-edge** | the *newest* language additions — user-defined functions, the `*`/`/` operators, parametric tuples (literals + indexing), and `///` doc-comments — pushed through `check → build → inspect tir` (needs tx3c ≥ 0.22) | compile/lower |
 
 `02-lang-tour` is compile/lower only: its feature-dense tx references hard-coded UTxOs, mints,
 and plutus scripts, so it can't resolve against a fresh devnet (the round-trip lives in 01).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -118,10 +118,11 @@ the native runners (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`):
   `02-lang-tour`'s tuples). Stable already covers everything broadly, so beta stays focused.
 
 Compat lives in one place — the journey's `#@ min-tx3c` header, enforced by the runner's skip gate —
-so the workflow needs no per-cell compat config. Each cell caches `~/.tx3/<channel>` (keyed on the
-channel manifest) to amortize installs. Native runners only: a DX test must validate the real
-per-platform install, which a Linux container would misrepresent (and drop macOS). Triggers: pushes
-to `main` touching `manifest-*.json` / `e2e/**` / the workflow; a nightly schedule; manual dispatch.
+so the workflow needs no per-cell compat config. The shared per-cell steps (install via tx3up, cache
+`~/.tx3/<channel>`, run one journey) live in the composite action `.github/actions/dx-e2e-run`.
+Native runners only: a DX test must validate the real per-platform install, which a Linux container
+would misrepresent (and drop macOS). Triggers: pushes to `main` touching `manifest-*.json` /
+`e2e/**` / the workflow / the action; a nightly schedule; manual dispatch.
 
 No journey here needs secrets. Future live-network journeys would run in a separate, secrets-gated
 job.

--- a/e2e/journeys/03-lang-edge/journey.sh
+++ b/e2e/journeys/03-lang-edge/journey.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Journey 03 — language edge.
+#
+# Coverage journey focused on the *newest* language-level additions, the
+# complement to 02-lang-tour's broad surface: user-defined functions (`fn` with
+# `let`), the `*` and `/` operators, parametric tuples (`Tuple<…>` types,
+# literals, and indexing), and `///` doc-comments. Swaps in this directory's
+# feature-dense main.tx3 and pushes it through compile + lower.
+#
+# Scope is compile/lower only (no devnet round-trip). These features need
+# tx3c >= 0.22, so the journey is skipped on older channels (e.g. stable's 0.21).
+#
+# Run via e2e/run.sh, which provides $TRIX and an isolated working directory.
+#
+#@ min-tx3c: 0.22.0
+
+source "${E2E_LIB:?E2E_LIB not set — run this journey via e2e/run.sh}"
+
+JOURNEY_HOME="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+journey_begin "03-lang-edge" "init → swap in edge-feature main.tx3 → check → build → inspect tir"
+
+# 1. Scaffold, then replace the trivial transfer with the edge-feature protocol.
+run_cmd "trix init -y — scaffold a new project" "${TRIX}" init -y
+cp "${JOURNEY_HOME}/main.tx3" main.tx3
+assert_exists "main.tx3" "edge-feature main.tx3 in place"
+
+# 2. Analyze the newest constructs through tx3c.
+run_cmd "trix check — analyze the edge-feature protocol" "${TRIX}" check
+assert_output_contains "check passed"
+
+# 3. Compile to TII — proves every construct lowers to the interface.
+run_cmd "trix build — compile edge-feature protocol to TII" "${TRIX}" build
+assert_found "TII artifact produced under .tx3/tii" ".tx3/tii" "main.tii"
+
+# 4. Lower `settle` and confirm functions + operators + tuple literals made it
+# through: the `*`/`/` from the inlined fns become Mul/Div eval nodes.
+run_cmd "trix inspect tir --tx settle — lower to TIR" "${TRIX}" inspect tir --tx settle
+assert_output_contains '"Mul"'   "multiply operator lowered"
+assert_output_contains '"Div"'   "divide operator lowered"
+assert_output_contains '"Tuple"' "tuple literal lowered"
+
+# 5. Lower `redeem` and confirm tuple *indexing* lowered (element access becomes
+# a Property node over the tuple).
+run_cmd "trix inspect tir --tx redeem — lower to TIR" "${TRIX}" inspect tir --tx redeem
+assert_output_contains '"Property"' "tuple indexing lowered"
+assert_output_contains '"Tuple"'    "tuple present in redeem"
+
+journey_end

--- a/e2e/journeys/03-lang-edge/main.tx3
+++ b/e2e/journeys/03-lang-edge/main.tx3
@@ -1,0 +1,67 @@
+/// Edge-feature tour: the newest Tx3 language additions — user-defined
+/// functions, the `*` and `/` operators, and parametric tuples (with these
+/// doc-comments carried through into the TII).
+
+/// Funds the settlement.
+party Owner;
+
+/// Receives the settled amount.
+party Beneficiary;
+
+type Quote {
+    terms: Tuple<Int, Int>,
+}
+
+fn gross(amount: Int, bps: Int) -> Int {
+    amount * bps / 10000
+}
+
+fn net(amount: Int, bps: Int) -> Int {
+    let fee = gross(amount, bps);
+    amount - fee
+}
+
+/// Settle `amount`, paying a basis-point `rate` fee to the beneficiary.
+tx settle(
+    /// The notional amount to settle.
+    amount: Int,
+    /// The fee rate in basis points (250 = 2.5%).
+    rate: Int,
+) {
+    input source {
+        from: Owner,
+        min_amount: Ada(amount) + fees,
+    }
+
+    output {
+        to: Beneficiary,
+        amount: Ada(net(amount, rate)),
+        datum: Quote {
+            terms: (rate, gross(amount, rate)),
+        },
+    }
+
+    output {
+        to: Owner,
+        amount: source - Ada(net(amount, rate)) - fees,
+    }
+}
+
+/// Redeem a quote, indexing back into the stored tuple.
+tx redeem(
+    /// Bump added to the stored rate.
+    bump: Int,
+) {
+    input source {
+        from: Beneficiary,
+        datum_is: Quote,
+    }
+
+    output {
+        to: Owner,
+        amount: source - fees,
+        datum: Quote {
+            terms: (source.terms[0] + bump, source.terms[1] / 2),
+        },
+    }
+}

--- a/skills/add-e2e-journey/SKILL.md
+++ b/skills/add-e2e-journey/SKILL.md
@@ -129,11 +129,11 @@ bash -n e2e/journeys/<NN>-<name>/journey.sh           # syntax
 ```
 
 ### 7. Place it in CI
-`.github/workflows/dx-e2e.yml` runs a static `{os × channel × journey}` matrix — **add your journey
-to the `journey` list** in that matrix. It runs against every channel; below-floor channels just
-install and skip it (the runner's `#@ min-tx3c` gate), so no per-cell compat config is needed.
-Journeys that need **secrets** (live network) belong in a separate, secrets-gated job — gate them so
-the fast `01` cells stay quick and secret-free.
+`.github/workflows/dx-e2e.yml` has one job per channel, each an `{os × journey}` matrix. **Add your
+journey to the `stable` job's `journey` list** (the comprehensive pass — below-floor journeys just
+install and skip via the `#@ min-tx3c` gate). **Also add it to the `beta` job's list only if it
+exercises a beta-only / edge feature** (`beta` is a focused cherry-pick, not the full suite).
+Journeys that need **secrets** (live network) belong in a separate, secrets-gated job.
 
 ## Decision Guidelines
 - **Strict vs xfail**: assert strictly by default. Reach for `xfail_cmd` *only* for a known,


### PR DESCRIPTION
## What

Two changes that go together:
1. **Per-channel CI jobs** — replace the single `{os × channel × journey}` matrix with one job per
   channel, each an `{os × journey}` matrix; shared per-cell steps live in a composite action.
2. **A new `03-lang-edge` journey** — the first real "edge-feature" journey, which is the concrete
   payoff of the beta cherry-pick design.

## Per-channel jobs

- **`stable`** — comprehensive pass over **every** journey. Edge journeys whose `#@ min-tx3c`
  exceeds stable's `tx3c` install + skip (green via the runner's gate), and auto-run once the
  feature graduates to stable.
- **`beta`** — cherry-picked **edge-feature** journeys only. Stable already covers the broad surface.
- **Composite action** `.github/actions/dx-e2e-run` holds the shared steps (install channel via
  tx3up → cache `~/.tx3/<channel>` → run one journey → upload artifacts). Each job is just
  `checkout` + the action.

Compat lives in one place — the journey's `#@ min-tx3c` header, enforced by the runner's skip gate.

## 03-lang-edge journey

Complements `02-lang-tour`'s breadth by focusing on the **newest** language additions: user-defined
functions (`fn` + `let`), the `*` / `/` operators, parametric tuples (literals + indexing), and
`///` doc-comments. It scaffolds, swaps in a feature-dense `main.tx3`, and runs
`check → build → inspect tir`, asserting the constructs lowered (`Mul`/`Div`/`Tuple` on `settle`,
tuple indexing → `Property` on `redeem`). Declares `#@ min-tx3c: 0.22.0`, so it runs on **beta** and
**skips on stable** (tx3c 0.21). Wired into both job lists (stable comprehensive / beta cherry-pick).

## Test plan

Validated locally on macOS against the beta toolchain:

- Full suite (default/beta): `01-basic-init`, `02-lang-tour`, `03-lang-edge` → **3 passed, 0 skipped**.
- `--local` @ stable: `03-lang-edge` **skipped** ("needs tx3c >= 0.22.0, have 0.21.0"), exit 0.
- The `03-lang-edge` fixture passes the tx3 diagnostics hook (`ok: true`) and its TIR shows the
  expected `Mul`/`Div`/`Tuple`/`Property` nodes.
- Workflow + composite-action YAML lint; matrices: `stable` = {01,02,03} × 3 OS, `beta` = {02,03} × 3 OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
