### PR TITLE
chore: release trix v0.26.1 to beta (pointer + manifest)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -22,7 +22,7 @@
       "description": "The tx3 package manager",
       "repo_name": "trix",
       "repo_owner": "tx3-lang",
-      "version": "^0.26.0"
+      "version": "^0.26.1"
     },
     {
       "name": "tx3-mcp",


### PR DESCRIPTION
Releases **trix v0.26.1** to the beta channel — ships trix#123 (the `trix test` expect/balance phase repair + utxorpc 0.12→0.13).

## Commits
1. **Pointer bump** — `tooling/trix` `0e9d854` → `057be51` (`v0.26.1`).
2. **Beta manifest** — `manifest-beta.json` trix `^0.26.0` → `^0.26.1` (makes the floor explicit; the caret already resolved 0.26.1).

## Why
trix v0.26.1 is published (cargo-dist binaries on the [GH release](https://github.com/tx3-lang/trix/releases/tag/v0.26.1)). This un-reds the strict beta e2e journey `04-devnet-roundtrip`, which installs released-channel binaries and resolves trix from the beta manifest.

## Scope / checks
- commit-umbrella pre-flight passes for trix (pushed ✓, at tip of main ✓, routing ✓).
- All other beta components already current (tx3c 0.22.0, tx3-mcp 0.5.0, tx3-lsp 0.10.0, dolos 1.2.0, cshell 0.14.0).
- **stable** channel untouched — still predates the fix (`trix ^0.25.1`).

## Unrelated note (not touched here)
`check-tracking` flags `tooling/tx3-lift` as BEHIND its origin/main — pre-existing drift on an out-of-scope submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)