### PR TITLE
chore: promote the lang-0.22 toolchain line to stable

### DIFF
--- a/.github/workflows/dx-e2e.yml
+++ b/.github/workflows/dx-e2e.yml
@@ -4,13 +4,12 @@ name: DX E2E
 # (install the channel via tx3up, cache it, run one journey) live in the local
 # composite action .github/actions/dx-e2e-run.
 #
-#   - stable: the offline scaffold gate + lang-surface journeys. Edge journeys
-#     whose `#@ min-tx3c` exceeds stable's tx3c install + skip (green), and
-#     auto-run once the feature graduates to stable.
+#   - stable: the offline scaffold gate + lang-surface journeys, plus the devnet
+#     round-trip (04). Edge journeys whose `#@ min-tx3c` exceeds stable's tx3c
+#     install + skip (green), and auto-run once the feature graduates to stable.
 #   - beta: edge-feature journeys (e.g. 02-lang-tour's tuples), plus the devnet
-#     round-trip (04). The round-trip currently *fails* on released channels (a
-#     known, tracked trix bug fixed on main but unreleased) — intentionally red,
-#     not a tolerated xfail; it goes green once the fix ships to a channel.
+#     round-trip (04), which exercises `trix test`'s expect/balance phase —
+#     repaired in trix 0.26.1, so it now runs green on both released channels.
 #
 # Compat lives in one place: the journey's `#@ min-tx3c` header, enforced by the
 # runner's skip gate. Native runners only — a DX test must exercise the real
@@ -42,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        journey: [01-basic-init, 02-lang-tour, 03-lang-edge]   # comprehensive: every journey
+        journey: [01-basic-init, 02-lang-tour, 03-lang-edge, 04-devnet-roundtrip]   # comprehensive: every journey
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dx-e2e-run
@@ -58,8 +57,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        # edge-feature journeys + the devnet round-trip. The round-trip fails on
-        # released channels until the trix fix ships (intentionally red, not xfail).
+        # edge-feature journeys + the devnet round-trip (trix test expect/balance,
+        # repaired in trix 0.26.1).
         journey: [02-lang-tour, 03-lang-edge, 04-devnet-roundtrip]
     steps:
       - uses: actions/checkout@v4

--- a/e2e/journeys/04-devnet-roundtrip/README.md
+++ b/e2e/journeys/04-devnet-roundtrip/README.md
@@ -5,14 +5,8 @@ local Dolos devnet, restores deterministic cshell wallets, submits the scaffolde
 asserts the resulting balances — exercising trix + tx3c + dolos + cshell + the resolver together.
 
 - **Scope:** runtime (needs a working devnet). No secrets, no live network beyond the one-time install.
-- **Channels:** runs everywhere (no `tx3c` floor), but the CI workflow currently schedules it on the
-  **beta** job only.
+- **Channels:** runs everywhere (no `tx3c` floor); scheduled on both the **stable** and **beta** jobs.
 
-## Currently failing on released channels — intentionally
-
-The balance-assertion phase hits a known, tracked trix bug (the expect path queried the wrong cshell
-store, passed the `@bob` placeholder, and parsed a mismatched utxo shape). Fixed on trix `main`
-(tx3-lang/trix#123) but not yet in a released channel, so this journey **fails** on released binaries.
-The assertion is kept **strict** (not a tolerated `xfail`) so the broken round-trip is a real,
-visible failure. It goes green automatically once the fix ships to a channel; at that point add this
-journey to the `stable` job too.
+The balance-assertion phase depends on `trix test`'s expect/balance handling, repaired in trix 0.26.1
+(tx3-lang/trix#123: the expect path had queried the wrong cshell store, passed the `@bob` placeholder,
+and parsed a mismatched utxo shape). The assertion is **strict** (not a tolerated `xfail`).

--- a/e2e/journeys/04-devnet-roundtrip/journey.sh
+++ b/e2e/journeys/04-devnet-roundtrip/journey.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #
-# Journey 04 — devnet round-trip. See README.md for what this covers (and why
-# it currently fails on released channels).
+# Journey 04 — devnet round-trip. See README.md for what this covers.
 # Run via e2e/run.sh, which provides $TRIX and an isolated working directory.
 
 source "${E2E_LIB:?E2E_LIB not set — run this journey via e2e/run.sh}"

--- a/manifest-stable.json
+++ b/manifest-stable.json
@@ -15,21 +15,28 @@
       "description": "The tx3 compiler",
       "repo_name": "tx3",
       "repo_owner": "tx3-lang",
-      "version": "^0.21.0"
+      "version": "^0.22.0"
     },
     {
       "name": "trix",
       "description": "The tx3 package manager",
       "repo_name": "trix",
       "repo_owner": "tx3-lang",
-      "version": "^0.25.1"
+      "version": "^0.26.1"
+    },
+    {
+      "name": "tx3-mcp",
+      "description": "An MCP server exposing the tx3 toolchain to AI agents and editors",
+      "repo_name": "tx3-mcp",
+      "repo_owner": "tx3-lang",
+      "version": "^0.5.0"
     },
     {
       "name": "tx3-lsp",
       "description": "A language server for tx3",
       "repo_name": "tx3-lsp",
       "repo_owner": "tx3-lang",
-      "version": "^0.9.0"
+      "version": "^0.10.0"
     },
     {
       "name": "dolos",


### PR DESCRIPTION
Promotes the now-validated **beta** toolchain line down to **stable**.

## Manifest (`manifest-stable.json`)
| Component | Was | Now |
|---|---|---|
| tx3c | `^0.21.0` | `^0.22.0` |
| trix | `^0.25.1` | `^0.26.1` |
| tx3-lsp | `^0.9.0` | `^0.10.0` |
| tx3-mcp | *(absent)* | `^0.5.0` (added) |
| dolos / cshell | `^1.2.0` / `^0.14.0` | unchanged |

**Coherence:** tx3c, trix, and tx3-lsp move as a unit — trix 0.26.x's `COMPAT_MATRIX` floor requires `tx3c >= 0.22.0`, so stable can't take trix 0.26.1 while pinning tx3c 0.21. tx3-mcp 0.5.0 (pins the =0.22 lang / =0.18 tir line) is added to stable per request.

## e2e (`dx-e2e.yml` + journey 04)
- Add `04-devnet-roundtrip` to the **stable** job's journey list. With trix 0.26.1 on stable it now passes (ships trix#123's expect/balance fix).
- Refresh the now-stale "intentionally red on released channels" comments in the workflow header, the journey `README.md`, and `journey.sh` — the fix has shipped to both channels.

## Notes
- Pushing to `manifest-*.json` / `e2e/**` triggers the DX E2E workflow on merge — the stable round-trip cell is the real validation of this promotion.
- Manifest edit kept in its own commit, separate from the e2e change (per channel-version-update guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)