### PR TITLE
chore: release cshell v0.14.1 to beta (pointer + manifest)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -50,7 +50,7 @@
       "description": "A terminal wallet for Cardano",
       "repo_name": "cshell",
       "repo_owner": "txpipe",
-      "version": "^0.14.0"
+      "version": "^0.14.1"
     }
   ]
 }


### PR DESCRIPTION
Promotes the freshly-released **cshell v0.14.1** (the `tx3-sdk` 0.9.2 → 0.13.0 bump, [txpipe/cshell#52](https://github.com/txpipe/cshell/pull/52)) to the beta channel.

- **Submodule pointer** — `tooling/cshell` → `ef237aa` (tag `v0.14.1`).
- **Beta manifest** — `cshell: ^0.14.0` → `^0.14.1` (kept in its own commit per AGENTS.md).

The v0.14.1 GitHub release is published with platform binaries (16 assets), so tx3up can resolve the new floor. Merging to `main` will cut a toolchain release with the updated manifests attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)