### PR TITLE
test(e2e): add 05-invoke journey for `trix invoke`

### DIFF
--- a/.github/workflows/dx-e2e.yml
+++ b/.github/workflows/dx-e2e.yml
@@ -8,9 +8,10 @@ name: DX E2E
 #     whose `#@ min-tx3c` exceeds stable's tx3c install + skip (green), and
 #     auto-run once the feature graduates to stable.
 #   - beta: edge-feature journeys (e.g. 02-lang-tour's tuples), plus the devnet
-#     round-trip (04). The round-trip currently *fails* on released channels (a
-#     known, tracked trix bug fixed on main but unreleased) — intentionally red,
-#     not a tolerated xfail; it goes green once the fix ships to a channel.
+#     round-trip (04) and the invoke arg-type journey (05). Both currently *fail*
+#     on released channels (known, tracked trix gaps fixed on main but unreleased)
+#     — intentionally red, not tolerated xfails; each goes green once its fix
+#     ships to a channel.
 #
 # Compat lives in one place: the journey's `#@ min-tx3c` header, enforced by the
 # runner's skip gate. Native runners only — a DX test must exercise the real
@@ -58,9 +59,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        # edge-feature journeys + the devnet round-trip. The round-trip fails on
-        # released channels until the trix fix ships (intentionally red, not xfail).
-        journey: [02-lang-tour, 03-lang-edge, 04-devnet-roundtrip]
+        # edge-feature journeys + the devnet round-trip (04) and the invoke
+        # arg-type journey (05). 04 and 05 fail on released channels until their
+        # trix fixes ship (intentionally red, not xfails).
+        journey: [02-lang-tour, 03-lang-edge, 04-devnet-roundtrip, 05-invoke]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dx-e2e-run

--- a/e2e/journeys/05-invoke/README.md
+++ b/e2e/journeys/05-invoke/README.md
@@ -1,0 +1,19 @@
+# 05-invoke
+
+Covers `trix invoke` — the command a consumer uses to bind CLI arguments to a transaction and
+resolve it against a TRP endpoint. A single flow: scaffold a project, bring up a local devnet, and
+invoke one transaction, asserting it resolves to an unsigned tx. The fixture's `transfer` tx takes a
+deliberately diverse argument set so the one invoke covers the breadth of the CLI arg surface.
+
+- **Scope:** runtime (needs a working devnet — Dolos + the TRP at `:8164`). No secrets, no live
+  network beyond the one-time install.
+- **Fixture:** `main.tx3`.
+- **Channels:** runs everywhere (no `tx3c` floor).
+
+## Resolve-only (`--skip-submit`)
+
+`trix invoke` always resolves against the TRP and hands cshell an empty signer set, so in a non-TTY
+(CI) signing is skipped — a full signed submit isn't reachable headlessly. The headless contract is
+resolve-only: it prints the unsigned `{ hash, cbor }`. Submission and balances are covered by
+`04-devnet-roundtrip`. The fixture is a single tx on purpose: invoke auto-selects the sole
+transaction instead of prompting (which would hang in CI).

--- a/e2e/journeys/05-invoke/journey.sh
+++ b/e2e/journeys/05-invoke/journey.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Journey 05 — trix invoke. See README.md for what this covers.
+# Run via e2e/run.sh, which provides $TRIX and an isolated working directory.
+
+source "${E2E_LIB:?E2E_LIB not set — run this journey via e2e/run.sh}"
+
+JOURNEY_HOME="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+journey_begin "05-invoke" "init → devnet → invoke a transaction and resolve it"
+
+# 1. Scaffold (gives the implicit `local` profile and a devnet.toml that funds
+#    alice/bob/charlie), then swap in the invoke fixture — a single tx so invoke
+#    auto-selects it without an interactive prompt.
+run_cmd "trix init -y — scaffold a new project" "${TRIX}" init -y
+cp "${JOURNEY_HOME}/main.tx3" main.tx3
+run_cmd "trix check — analyze the fixture" "${TRIX}" check
+assert_output_contains "check passed"
+
+# 2. Resolve the deterministic party addresses (parties bind as Address args).
+ALICE="$("${TRIX}" identities alice address-testnet 2>/dev/null | grep '^addr' | head -n1)"
+BOB="$("${TRIX}" identities bob address-testnet 2>/dev/null | grep '^addr' | head -n1)"
+[[ -n "${ALICE}" && -n "${BOB}" ]] || die "could not resolve alice/bob testnet addresses"
+
+# 3. Bring up a local devnet (Dolos + TRP at :8164) — invoke resolves against it.
+#    Record the dolos PIDs we spawn and trap-kill only those, so an aborted
+#    assertion never leaves a daemon behind.
+run_cmd "trix devnet --background — start a local devnet" "${TRIX}" devnet --background
+assert_output_contains "devnet started in background"
+DEVNET_PIDS="$(pgrep -f 'dolos.*daemon' | tr '\n' ' ')"
+# shellcheck disable=SC2064
+trap "[[ -n \"${DEVNET_PIDS}\" ]] && kill -9 ${DEVNET_PIDS} 2>/dev/null" EXIT
+for _ in $(seq 1 30); do
+  (exec 3<>/dev/tcp/127.0.0.1/8164) 2>/dev/null && { exec 3>&- 3<&-; break; }
+  sleep 1
+done
+sleep 3
+
+# 4. Invoke the transaction — passing the fixture's full argument set — and
+#    require it to resolve to an unsigned tx. --skip-submit keeps it headless:
+#    invoke never signs without a TTY (see README), so resolve-only is the mode.
+#
+#    This currently FAILS on released channels because the toolchain can't yet
+#    bind the fixture's full argument set (resolve errors with "invalid param
+#    type"). The assertion is kept strict — an intentional red, not an xfail —
+#    so the gap stays visible and the journey goes green the moment it's fixed.
+#    Tracked in plans/invoke-arg-type-support-gap.md.
+run_cmd "trix invoke — resolve the transaction" \
+  "${TRIX}" invoke --skip-submit \
+  --args-json "{\"sender\":\"${ALICE}\",\"receiver\":\"${BOB}\",\"quantity\":2000000,\"urgent\":true,\"memo\":\"deadbeef\",\"meta\":{\"tags\":[1,2,3],\"level\":7}}"
+assert_output_contains '"cbor"' "invoke resolved to an unsigned transaction"
+assert_output_contains '"hash"' "resolved tx carries a hash"
+
+journey_end

--- a/e2e/journeys/05-invoke/main.tx3
+++ b/e2e/journeys/05-invoke/main.tx3
@@ -1,0 +1,48 @@
+// Single-tx invoke fixture (journey 05). Exactly one `tx` so `trix invoke`
+// auto-selects it without an interactive prompt. The transfer spends the
+// Sender's funded input, writes a datum-bearing output, and returns the change,
+// while taking a deliberately diverse set of argument types so one invoke
+// exercises the breadth of the arg surface: Int (quantity), Bool (urgent),
+// Bytes (memo), Address (sender/receiver, from the parties), and a complex
+// record (meta) that nests a parametric List<Int>.
+party Sender;
+
+party Receiver;
+
+type Meta {
+    tags: List<Int>,
+    level: Int,
+}
+
+type Payload {
+    memo: Bytes,
+    urgent: Bool,
+    meta: Meta,
+}
+
+tx transfer(
+    quantity: Int,
+    urgent: Bool,
+    memo: Bytes,
+    meta: Meta,
+) {
+    input source {
+        from: Sender,
+        min_amount: Ada(quantity) + fees,
+    }
+
+    output {
+        to: Receiver,
+        amount: Ada(quantity),
+        datum: Payload {
+            memo: memo,
+            urgent: urgent,
+            meta: meta,
+        },
+    }
+
+    output {
+        to: Sender,
+        amount: source - Ada(quantity) - fees,
+    }
+}

--- a/plans/invoke-arg-type-support-gap.md
+++ b/plans/invoke-arg-type-support-gap.md
@@ -1,0 +1,92 @@
+# Bug: `trix invoke` only binds `Int` / `Bool` / `Address` args — everything else fails
+
+Status: **tracked, not yet fixed.** Reproduces on `stable` (trix 0.25.1) and the default/`beta`
+channel (trix 0.26.0). Surfaced by the `05-invoke` DX e2e journey, which invokes a tx with a
+diverse arg spread and strictly asserts it resolves — so it's **intentionally red** on released
+channels (parked on the `beta` CI job, like `04-devnet-roundtrip`) until the gap below closes.
+
+## Symptom
+
+`trix check` passes and `trix build` produces a valid TII, but `trix invoke` (and `cshell tx
+invoke` underneath) fails the moment any non-`Int`/`Bool`/`Address` argument is supplied via
+`--args-json` / `--args-json-path`:
+
+```
+❗️ error: invalid param type
+```
+
+Verified failing arg types: `Bytes`, and the complex types `record` (custom type), `List<_>`,
+`Map<_,_>`, `Tuple<_>`, and `AnyAsset`. `UtxoRef` goes through the same path and is expected to
+fail too (it additionally needs pre-existing on-chain state to resolve).
+
+## Root cause
+
+The error is `tx3_sdk::tii::Error::InvalidParamType`, returned from `ParamType::from_json_schema`
+at protocol-load time (`Protocol::from_file`, before any network call). That function is narrow —
+it only recognizes three core-type `$ref`s plus scalar instance types, and errors on everything
+else:
+
+```rust
+pub fn from_json_schema(schema: Schema) -> Result<ParamType, Error> {
+    let as_object = schema.into_object();
+    if let Some(reference) = &as_object.reference {
+        return match reference.as_str() {
+            "https://tx3.land/specs/v1beta0/core#Bytes"   => Ok(ParamType::Bytes),
+            "https://tx3.land/specs/v1beta0/core#Address" => Ok(ParamType::Address),
+            "https://tx3.land/specs/v1beta0/core#UtxoRef" => Ok(ParamType::UtxoRef),
+            _ => Err(Error::InvalidParamType),
+        };
+    }
+    if let Some(inner) = as_object.instance_type {
+        return match inner {
+            SingleOrVec::Single(x) => Self::from_json_type(*x), // only Integer / Boolean
+            SingleOrVec::Vec(_)    => Err(Error::InvalidParamType),
+        };
+    }
+    Err(Error::InvalidParamType)
+}
+```
+
+This yields **two distinct failure modes**, both surfacing as the same `invalid param type`:
+
+1. **`Bytes` / `UtxoRef` — `$ref` mismatch (a typo-class bug).** tx3c emits the param schema as
+   `"$ref": "https://tx3.land/specs/v1beta0/tii#/$defs/Bytes"`, but the matcher above keys on
+   `…/v1beta0/core#Bytes`. `…/tii#/$defs/Bytes` ≠ `…/core#Bytes`, so it falls through.
+
+2. **Complex types — unimplemented.** A record param emits `"$ref": "#/components/schemas/Meta"`;
+   a `List<_>` emits an `array`/`Vec` instance type. `from_json_schema` has no branch for local
+   `#/components/schemas/…` (or `#/$defs/…`) references, no array/`List` handling, and no object
+   handling — so records, lists, maps, tuples and `AnyAsset` all hit a catch-all `InvalidParamType`.
+
+Why `Int`/`Bool`/`Address` survive: `Int`→`{"type":"integer"}` and `Bool`→`{"type":"boolean"}` are
+matched by instance type; `Address` works *as an argument* only because parties are injected as
+`ParamType::Address` directly (`tii/mod.rs`, `out.params.insert(party.to_lowercase(),
+ParamType::Address)`), never routed through `from_json_schema`. A non-party `Address` param would
+hit the same wall.
+
+## Secondary bug: `trix invoke` exits 0 on a resolve error
+
+Independently of the above, `trix invoke` prints `❗️ error: invalid param type` and then **exits
+`0`**. A failed resolve should be a non-zero exit. This shapes the `05-invoke` journey: because the
+invoke exits 0, the runner's `run_cmd` doesn't abort, so the strict `"cbor"` assertion is what turns
+the journey red (and it's why the exit-code-based `xfail_cmd` helper can't be used here — it would
+misread the zero exit as success). Worth fixing alongside the type support so resolve failures are
+detectable by exit code.
+
+## Fix options (for whoever picks this up)
+
+- **`Bytes` / `UtxoRef`:** align the URIs — either tx3c emits `…/core#Bytes`, or `from_json_schema`
+  also accepts `…/tii#/$defs/<T>` (accept both during the transition).
+- **Complex types:** teach `from_json_schema` to resolve local component/`$defs` refs into
+  `ParamType::Custom(Schema)`, handle `array` → `ParamType::List`, and cover map/tuple/`AnyAsset`.
+- **Exit code:** return non-zero from `trix invoke` (and `cshell tx invoke`) on a resolve error.
+
+Whichever side moves, bump the toolchain so a released channel carries the fix.
+
+## Verification when fixed
+
+The `05-invoke` journey auto-detects the fix: its diverse-typed invoke starts resolving to a
+`cbor`, the strict assertion passes, and the journey goes green — at which point move it from the
+`beta` CI matrix onto `stable` and delete this note. The fine-grained per-type matrix (one case per
+`Bytes`/`UtxoRef`/record/`List`/`Map`/`Tuple`/`AnyAsset`) is better covered by trix's own unit
+tests than by the e2e journey, which only needs the one end-to-end resolve.


### PR DESCRIPTION
## What

Adds a runtime DX e2e journey, **`05-invoke`**, that drives `trix invoke` end-to-end. `run.sh` auto-discovers it; it's wired into the **beta** CI matrix.

A single flow — scaffold → local devnet → invoke one transaction — asserting it resolves to an unsigned tx. The fixture's `transfer` tx takes a deliberately diverse argument set so the one invoke covers the breadth of the CLI arg surface.

## Notes

- **Resolve-only (`--skip-submit`)** — the only headless mode: `trix invoke` always resolves against the TRP and never signs without a TTY. Submission + balances stay covered by `04-devnet-roundtrip`.
- **Single-tx fixture** so invoke auto-selects it instead of prompting (which would hang in CI).

## Currently failing on released channels — intentionally

The toolchain can't yet bind the fixture's full argument set via the CLI, so the invoke errors at resolve with `invalid param type`. Found while building this; root causes + fix options are recorded in `plans/invoke-arg-type-support-gap.md`.

The strict assertion (invoke must resolve to a `cbor`) therefore **fails** on released binaries today. It's kept strict — an **intentional red, not a tolerated `xfail`** — so the gap stays visible and the journey greens automatically once the toolchain catches up. Parked on the **beta** job alongside `04`; move to `stable` when the fix ships.

## Verification

- ✅ flow drives end-to-end; fails cleanly at the strict `"cbor"` assertion (the intended red) on the current toolchain.
- ✅ hermetic — cleanup trap kills only the dolos PIDs it spawned, even on the failing assertion; no stray daemon after the run.
- ✅ behaves identically on `stable` (trix 0.25.1) and `beta`/default (0.26.0); no `#@ min-tx3c` floor needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)