### PR TITLE
chore: promote beta-validated toolchain set to stable (+ add tx3-mcp)

### DIFF
--- a/manifest-stable.json
+++ b/manifest-stable.json
@@ -25,6 +25,13 @@
       "version": "^0.26.2"
     },
     {
+      "name": "tx3-mcp",
+      "description": "An MCP server exposing the tx3 toolchain to AI agents and editors",
+      "repo_name": "tx3-mcp",
+      "repo_owner": "tx3-lang",
+      "version": "^0.5.0"
+    },
+    {
       "name": "tx3-lsp",
       "description": "A language server for tx3",
       "repo_name": "tx3-lsp",

--- a/manifest-stable.json
+++ b/manifest-stable.json
@@ -15,21 +15,21 @@
       "description": "The tx3 compiler",
       "repo_name": "tx3",
       "repo_owner": "tx3-lang",
-      "version": "^0.21.0"
+      "version": "^0.22.0"
     },
     {
       "name": "trix",
       "description": "The tx3 package manager",
       "repo_name": "trix",
       "repo_owner": "tx3-lang",
-      "version": "^0.25.1"
+      "version": "^0.26.2"
     },
     {
       "name": "tx3-lsp",
       "description": "A language server for tx3",
       "repo_name": "tx3-lsp",
       "repo_owner": "tx3-lang",
-      "version": "^0.9.0"
+      "version": "^0.10.0"
     },
     {
       "name": "dolos",
@@ -43,7 +43,7 @@
       "description": "A terminal wallet for Cardano",
       "repo_name": "cshell",
       "repo_owner": "txpipe",
-      "version": "^0.14.0"
+      "version": "^0.14.1"
     }
   ]
 }


### PR DESCRIPTION
Promote the beta-validated component versions onto the **stable** channel, per the `channel-version-update` skill, and bring stable's tool set in line with beta by adding `tx3-mcp`.

| Component | stable (was) | → now | Notes |
|---|---|---|---|
| tx3c | `^0.21.0` | `^0.22.0` | required by trix's compat floor |
| trix | `^0.25.1` | `^0.26.2` | invoke exit-code fix (#124) + test/devnet repair |
| **tx3-mcp** | _(absent)_ | `^0.5.0` | **newly added** — MCP server; now matches beta |
| tx3-lsp | `^0.9.0` | `^0.10.0` | latest |
| cshell | `^0.14.0` | `^0.14.1` | tx3-sdk 0.13.0 — complex param-type recognition |
| dolos | `^1.2.0` | `^1.2.0` | already current |

### Coupling
tx3c and trix move **together**: trix 0.26.x raises its `COMPAT_MATRIX` floor to tx3c 0.22.0 (parametric tuple types in the TIR that pre-0.22 readers can't decode). Bumping trix without tx3c would break the floor.

### Scope
- `tx3-mcp ^0.5.0` is added so stable carries the same tool set as beta.
- These versions are all currently live and green on the beta channel (`02-lang-tour` tuples, `04-devnet-roundtrip`, etc.).
- `05-invoke` is beta-only and stays intentionally red until the complex-arg resolver work ships (see `plans/complex-arg-type-support.md`); this promotion does not affect it.

After merge, the push-to-`main` `dx-e2e` run exercises the stable matrix (`01-basic-init`, `02-lang-tour`, `03-lang-edge`) against the new pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)