### PR TITLE
ci(dx-e2e): cap matrix parallelism to avoid tx3up install saturation

### DIFF
--- a/.github/workflows/dx-e2e.yml
+++ b/.github/workflows/dx-e2e.yml
@@ -39,9 +39,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # a cache-miss burst of concurrent `tx3up install`s trips the releases-API rate limit
+      max-parallel: 3
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        journey: [01-basic-init, 02-lang-tour, 03-lang-edge]   # comprehensive: every journey
+        journey: [01-basic-init, 02-lang-tour, 03-lang-edge]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dx-e2e-run
@@ -55,6 +57,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         # edge-feature journeys plus the runtime journeys: the devnet


### PR DESCRIPTION
## Problem

A manifest change invalidates that channel's cache key (`hashFiles(manifest-<channel>.json)` in the composite action), so **every** matrix cell for that channel cache-misses and runs `tx3up install` at the same time. The burst of `releases/latest` lookups trips a GitHub API **secondary rate limit**, which tx3up surfaces as:

```
Error: No manifest asset found in latest release
✗ tx3up install failed for channel '<channel>'
```

These are scattered, install-step failures unrelated to the journeys. Observed on both recent manifest merges (#26 beta, #27 stable); each needed a manual re-run to go green.

## Fix

Set `max-parallel: 3` on both channel jobs. A single-channel cache-miss burst drops from **9–12 concurrent installs to 3**, comfortably under the rate limit. Warm-cache runs (the common case) are unaffected in substance and only marginally slower — the journeys are seconds-scale.

`max-parallel` is per matrix job, so `stable` and `beta` keep their own caps; since a manifest edit only cache-misses one channel, the effective worst-case burst is 3.

## Notes
- Prevents the burst rather than absorbing it (vs. a retry-with-backoff around the install) — declarative and doesn't risk masking a genuinely broken channel.
- No change to which journeys run or their pass/fail semantics; `05-invoke` stays intentionally red on beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)