### PR TITLE
chore: promote complex-arg set to stable + graduate 05-invoke

### DIFF
--- a/.github/workflows/dx-e2e.yml
+++ b/.github/workflows/dx-e2e.yml
@@ -43,7 +43,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        journey: [01-basic-init, 02-lang-tour, 03-lang-edge]
+        journey: [01-basic-init, 02-lang-tour, 03-lang-edge, 05-invoke]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dx-e2e-run

--- a/e2e/journeys/05-invoke/journey.sh
+++ b/e2e/journeys/05-invoke/journey.sh
@@ -2,6 +2,8 @@
 #
 # Journey 05 — trix invoke. See README.md for what this covers.
 # Run via e2e/run.sh, which provides $TRIX and an isolated working directory.
+#
+#@ min-tx3c: 0.23.0
 
 source "${E2E_LIB:?E2E_LIB not set — run this journey via e2e/run.sh}"
 

--- a/manifest-stable.json
+++ b/manifest-stable.json
@@ -15,7 +15,7 @@
       "description": "The tx3 compiler",
       "repo_name": "tx3",
       "repo_owner": "tx3-lang",
-      "version": "^0.22.0"
+      "version": "^0.23.0"
     },
     {
       "name": "trix",
@@ -43,14 +43,14 @@
       "description": "A lightweight Cardano data node",
       "repo_name": "dolos",
       "repo_owner": "txpipe",
-      "version": "^1.2.0"
+      "version": "^1.3.2"
     },
     {
       "name": "cshell",
       "description": "A terminal wallet for Cardano",
       "repo_name": "cshell",
       "repo_owner": "txpipe",
-      "version": "^0.14.1"
+      "version": "^0.15.0"
     }
   ]
 }


### PR DESCRIPTION
Promotes the beta-validated complex-argument toolchain set to the **stable** channel and graduates the `05-invoke` journey to run there.

## Stable manifest (own commit)

`channel-version-update` for stable — the three sprint components reached their latest stable releases (trix/tx3-mcp/tx3-lsp already current):

| component | was | now |
|---|---|---|
| `tx3c` | `^0.22.0` | `^0.23.0` |
| `dolos` | `^1.2.0` | `^1.3.2` |
| `cshell` | `^0.14.1` | `^0.15.0` |

## Graduate `05-invoke`

- Added to the **stable** journey matrix in `dx-e2e.yml` (was beta-only); kept in beta too.
- Gave it a `#@ min-tx3c: 0.23.0` header — the harness skips it green on any channel whose tx3c install is below the floor, and auto-runs it once the channel carries the feature. With the manifest bump above, stable now installs `tx3c 0.23.0` ≥ floor, so it runs.

## Confidence

`05-invoke` is already green on **beta** with the identical version set (`tx3c 0.23.0` / `dolos 1.3.2` / `cshell 0.15.0`) — verified end to end (`meta` record nesting `List<Int>` → `cbor`/`hash`). The stable channel installs the same artifacts, so promotion is the validated beta set moving forward.

Merging triggers `release.yml` to cut the stable release with the new manifest; the stable e2e matrix then runs `05-invoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)